### PR TITLE
docs(readme): remove CORS Credentials header

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,9 @@ const ipfs = window.IpfsHttpClient()
 
 In a web browser IPFS HTTP client (either browserified or CDN-based) might encounter an error saying that the origin is not allowed. This would be a CORS ("Cross Origin Resource Sharing") failure: IPFS servers are designed to reject requests from unknown domains by default. You can whitelist the domain that you are calling from by changing your ipfs config like this:
 
-```bash
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"http://example.com\"]"
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials "[\"true\"]"
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods "[\"PUT\", \"POST\", \"GET\"]"
+```console
+$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin  '["http://example.com"]'
+$ ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST", "GET"]'
 ```
 
 ### Custom Headers


### PR DESCRIPTION
(afaik) HTTP API does not need this and we should not ask people to set it if they don't really need it.

See also:

- Potential problem with  `Access-Control-Allow-Credentials`: https://github.com/ipfs/go-ipfs/issues/5745
- HTTP Headers Cleanup: https://github.com/ipfs/in-web-browsers/issues/132
