### PR TITLE
fix: properly serialize CID instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-react": "^7.11.1",
     "go-ipfs-dep": "~0.4.18",
     "gulp": "^3.9.1",
-    "interface-ipfs-core": "~0.91.0",
+    "interface-ipfs-core": "~0.92.0",
     "ipfsd-ctl": "~0.40.0",
     "nock": "^10.0.2",
     "pull-stream": "^3.6.9",

--- a/src/files-regular/ls-pull-stream.js
+++ b/src/files-regular/ls-pull-stream.js
@@ -3,6 +3,7 @@
 const moduleConfig = require('../utils/module-config')
 const pull = require('pull-stream')
 const deferred = require('pull-defer')
+const cleanCID = require('../utils/clean-cid')
 
 module.exports = (arg) => {
   const send = moduleConfig(arg)
@@ -11,6 +12,12 @@ module.exports = (arg) => {
     if (typeof (opts) === 'function') {
       callback = opts
       opts = {}
+    }
+
+    try {
+      args = cleanCID(args)
+    } catch (err) {
+      return callback(err)
     }
 
     const p = deferred.source()

--- a/src/files-regular/ls-readable-stream.js
+++ b/src/files-regular/ls-readable-stream.js
@@ -2,6 +2,7 @@
 
 const moduleConfig = require('../utils/module-config')
 const Stream = require('readable-stream')
+const cleanCID = require('../utils/clean-cid')
 
 module.exports = (arg) => {
   const send = moduleConfig(arg)
@@ -10,6 +11,12 @@ module.exports = (arg) => {
     if (typeof (opts) === 'function') {
       callback = opts
       opts = {}
+    }
+
+    try {
+      args = cleanCID(args)
+    } catch (err) {
+      return callback(err)
     }
 
     const pt = new Stream.PassThrough({ objectMode: true })

--- a/src/files-regular/ls.js
+++ b/src/files-regular/ls.js
@@ -2,6 +2,7 @@
 
 const promisify = require('promisify-es6')
 const moduleConfig = require('../utils/module-config')
+const cleanCID = require('../utils/clean-cid')
 
 module.exports = (arg) => {
   const send = moduleConfig(arg)
@@ -11,6 +12,13 @@ module.exports = (arg) => {
       callback = opts
       opts = {}
     }
+
+    try {
+      args = cleanCID(args)
+    } catch (err) {
+      return callback(err)
+    }
+
     send({
       path: 'ls',
       args: args,

--- a/src/utils/clean-cid.js
+++ b/src/utils/clean-cid.js
@@ -1,18 +1,17 @@
 'use strict'
 
-const bs58 = require('bs58')
 const CID = require('cids')
 
 module.exports = function (cid) {
   if (Buffer.isBuffer(cid)) {
-    cid = bs58.encode(cid)
+    return new CID(cid).toString()
   }
   if (CID.isCID(cid)) {
-    cid = cid.toBaseEncodedString()
+    return cid.toString()
   }
   if (typeof cid !== 'string') {
     throw new Error('unexpected cid type: ' + typeof cid)
   }
-  CID.validateCID(new CID(cid.split('/')[0]))
+  new CID(cid.split('/')[0]) // eslint-disable-line
   return cid
 }

--- a/src/utils/clean-cid.js
+++ b/src/utils/clean-cid.js
@@ -12,6 +12,6 @@ module.exports = function (cid) {
   if (typeof cid !== 'string') {
     throw new Error('unexpected cid type: ' + typeof cid)
   }
-  new CID(cid.split('/')[0]) // eslint-disable-line
+  new CID(cid.split('/')[0]) // eslint-disable-line no-new
   return cid
 }

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -34,7 +34,12 @@ describe('interface-ipfs-core tests', () => {
     ]
   })
 
-  tests.block(defaultCommonFactory)
+  tests.block(defaultCommonFactory, {
+    skip: [{
+      name: 'should get a block added as CIDv1 with a CIDv0',
+      reason: 'go-ipfs does not support the `version` param'
+    }]
+  })
 
   tests.bootstrap(defaultCommonFactory)
 


### PR DESCRIPTION
The CID version agnostic tests https://github.com/ipfs/interface-ipfs-core/pull/413 identified some functions were not properly serializing CID instances. This PR adds `cleanCID` step to several functions and also updates the `cleanCID` function to not assume buffer CIDs are CIDv0 multihashes.

* [x] depends on https://github.com/ipfs/interface-ipfs-core/pull/413