### PR TITLE
fix: added rm method for blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ const ipfs = ipfsClient({
 - [block](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/BLOCK.md)
   - [`ipfs.block.get(cid, [options], [callback])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/BLOCK.md#blockget)
   - [`ipfs.block.put(block, [options], [callback])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/BLOCK.md#blockput)
+  - [`ipfs.block.rm(cid, [callback])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/BLOCK.md#blockrm)
   - [`ipfs.block.stat(cid, [callback])`](https://github.com/ipfs/interface-ipfs-core/blob/master/SPEC/BLOCK.md#blockstat)
 
 #### Graph

--- a/src/block/index.js
+++ b/src/block/index.js
@@ -8,6 +8,7 @@ module.exports = (arg) => {
   return {
     get: require('./get')(send),
     stat: require('./stat')(send),
-    put: require('./put')(send)
+    put: require('./put')(send),
+    rm: require('./rm')(send)
   }
 }

--- a/src/block/rm.js
+++ b/src/block/rm.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const promisify = require('promisify-es6')
+const CID = require('cids')
+const multihash = require('multihashes')
+
+module.exports = (send) => {
+  return promisify((args, opts, callback) => {
+    if (args && CID.isCID(args)) {
+      args = multihash.toB58String(args.multihash)
+    }
+
+    if (typeof (opts) === 'function') {
+      callback = opts
+      opts = {}
+    }
+
+    const request = {
+      path: 'block/rm',
+      args: args,
+      qs: opts
+    }
+
+    // Transform the response from { Key, Size } objects to { key, size } objects
+    const transform = (stats, callback) => {
+      callback(null)
+    }
+
+    send.andTransform(request, transform, callback)
+  })
+}


### PR DESCRIPTION
I've seen a command "ipfs block rm" in a CLI commands lists and HTTP, but seems like it is absent in `js-ipfs-http-client` package. I've opened this basic merge-request that adds it, but I am not sure what else should got here. Tested on my pet project, `ipfs.block.rm` worked like a charm.

resolves #792