### PR TITLE
chore: use Object.assign instead of spread operator

### DIFF
--- a/src/files-mfs/ls-readable-stream.js
+++ b/src/files-mfs/ls-readable-stream.js
@@ -36,10 +36,7 @@ module.exports = (send) => {
     send({
       path: 'files/ls',
       args: args,
-      qs: {
-        ...opts,
-        stream: true
-      }
+      qs: Object.assign({}, opts, { stream: true }),
     }, (err, res) => {
       if (err) {
         return output.destroy(err)

--- a/src/files-mfs/ls-readable-stream.js
+++ b/src/files-mfs/ls-readable-stream.js
@@ -36,7 +36,7 @@ module.exports = (send) => {
     send({
       path: 'files/ls',
       args: args,
-      qs: Object.assign({}, opts, { stream: true }),
+      qs: Object.assign({}, opts, { stream: true })
     }, (err, res) => {
       if (err) {
         return output.destroy(err)


### PR DESCRIPTION
This way the requiring lib doesn't have to support the spread operator.