### PR TITLE
fix: re-allow passing path to ls

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-react": "^7.11.1",
     "go-ipfs-dep": "~0.4.18",
     "gulp": "^3.9.1",
-    "interface-ipfs-core": "~0.92.0",
+    "interface-ipfs-core": "~0.93.0",
     "ipfsd-ctl": "~0.40.0",
     "nock": "^10.0.2",
     "pull-stream": "^3.6.9",

--- a/src/files-regular/ls-pull-stream.js
+++ b/src/files-regular/ls-pull-stream.js
@@ -3,6 +3,7 @@
 const moduleConfig = require('../utils/module-config')
 const pull = require('pull-stream')
 const deferred = require('pull-defer')
+const IsIpfs = require('is-ipfs')
 const cleanCID = require('../utils/clean-cid')
 
 module.exports = (arg) => {
@@ -17,7 +18,9 @@ module.exports = (arg) => {
     try {
       args = cleanCID(args)
     } catch (err) {
-      return callback(err)
+      if (!IsIpfs.ipfsPath(args)) {
+        return callback(err)
+      }
     }
 
     const p = deferred.source()

--- a/src/files-regular/ls-readable-stream.js
+++ b/src/files-regular/ls-readable-stream.js
@@ -2,6 +2,7 @@
 
 const moduleConfig = require('../utils/module-config')
 const Stream = require('readable-stream')
+const IsIpfs = require('is-ipfs')
 const cleanCID = require('../utils/clean-cid')
 
 module.exports = (arg) => {
@@ -16,7 +17,9 @@ module.exports = (arg) => {
     try {
       args = cleanCID(args)
     } catch (err) {
-      return callback(err)
+      if (!IsIpfs.ipfsPath(args)) {
+        return callback(err)
+      }
     }
 
     const pt = new Stream.PassThrough({ objectMode: true })

--- a/src/files-regular/ls.js
+++ b/src/files-regular/ls.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const IsIpfs = require('is-ipfs')
 const moduleConfig = require('../utils/module-config')
 const cleanCID = require('../utils/clean-cid')
 
@@ -16,7 +17,9 @@ module.exports = (arg) => {
     try {
       args = cleanCID(args)
     } catch (err) {
-      return callback(err)
+      if (!IsIpfs.ipfsPath(args)) {
+        return callback(err)
+      }
     }
 
     send({


### PR DESCRIPTION
This was accidentally disabled and no tests existed to catch it.

* [x] depends on https://github.com/ipfs/interface-ipfs-core/pull/420