### PR TITLE
fix: bundle in meteor

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     "glob": false,
     "fs": false,
     "stream": "readable-stream",
-    "http": "stream-http",
-    "ipfs-http-client": false,
-    "ipfs": false
+    "http": "stream-http"
   },
   "scripts": {
     "test": "aegir test",


### PR DESCRIPTION
Including `ipfs-http-client` in the `browser` field of package.json was causing Meteor to not include the bundle in it's browser build.

I have no idea why it is there! @daviddias do you remember why it was added?

fixes #924