### PR TITLE
feat: return protocol from getEndpointConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Complete documentation for these methods is coming with: https://github.com/ipfs
 
 > `ipfs.util.getEndpointConfig()`
 
-This returns an object containing the `host` and the `port`
+This returns an object containing the `host`, `port` and `protocol`
 
 ##### Get libp2p crypto primitives
 

--- a/src/util/get-endpoint-config.js
+++ b/src/util/get-endpoint-config.js
@@ -4,6 +4,7 @@ module.exports = (config) => {
   return () => ({
     host: config.host,
     port: config.port,
-    protocol: config.protocol
+    protocol: config.protocol,
+    'api-path': config['api-path']
   })
 }

--- a/src/util/get-endpoint-config.js
+++ b/src/util/get-endpoint-config.js
@@ -3,6 +3,7 @@
 module.exports = (config) => {
   return () => ({
     host: config.host,
-    port: config.port
+    port: config.port,
+    protocol: config.protocol
   })
 }

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -35,10 +35,12 @@ describe('.util', () => {
   })
 
   describe('.getEndpointConfig', () => {
-    it('should return the endpoint configured host and port', function () {
+    it('should return the endpoint configuration', function () {
       const endpoint = ipfs.util.getEndpointConfig()
 
-      expect(endpoint).to.have.property('host')
+      expect(endpoint.host).to.equal('127.0.0.1')
+      expect(endpoint.protocol).to.equal('http')
+      // changes per test run so we just assert it exists.
       expect(endpoint).to.have.property('port')
     })
   })

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -43,7 +43,6 @@ describe('.util', () => {
       expect(endpoint['api-path']).to.equal('/api/v0/')
       // changes per test run so we just assert it exists.
       expect(endpoint).to.have.property('port')
-
     })
   })
 

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -40,8 +40,10 @@ describe('.util', () => {
 
       expect(endpoint.host).to.equal('127.0.0.1')
       expect(endpoint.protocol).to.equal('http')
+      expect(endpoint['api-path']).to.equal('/api/v0/')
       // changes per test run so we just assert it exists.
       expect(endpoint).to.have.property('port')
+
     })
   })
 


### PR DESCRIPTION
The protocol is used to construct the request, and it's useful to be able to check it has been set correctly. This PR adds it to the `util.getEndpointConfig()` return value.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>