### PR TITLE
Update required Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "through2": "^3.0.0"
   },
   "engines": {
-    "node": ">=8.0.0",
+    "node": ">=10.0.0",
     "npm": ">=3.0.0"
   },
   "repository": {


### PR DESCRIPTION
Readme says that minimum Node.js version is 10. This is true because of some dependencies which also require version 10. However, in `package.json` file, minimum version is 8. This is incorrect, so I'm fixing this now.