### PR TITLE
PUBSUB: unsubscribe without handler reference

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -12,7 +12,7 @@ module.exports = {
   },
   karma: {
     files: [{
-      pattern: 'node_modules/interface-ipfs-core/js/test/fixtures/**/*',
+      pattern: 'node_modules/interface-ipfs-core/test/fixtures/**/*',
       watched: false,
       served: true,
       included: false

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "dirty-chai": "^2.0.1",
     "eslint-plugin-react": "^7.11.1",
     "go-ipfs-dep": "~0.4.18",
-    "interface-ipfs-core": "~0.96.0",
+    "interface-ipfs-core": "~0.98.0",
     "ipfsd-ctl": "github:ipfs/js-ipfsd-ctl",
     "nock": "^10.0.2",
     "pull-stream": "^3.6.9",

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -77,7 +77,11 @@ module.exports = (arg) => {
         return setImmediate(() => callback(err))
       }
 
-      ps.removeListener(topic, handler)
+      if (!handler && !callback) {
+        ps.removeAllListeners(topic)
+      } else {
+        ps.removeListener(topic, handler)
+      }
 
       // Drop the request once we are actually done
       if (ps.listenerCount(topic) === 0) {

--- a/test/get.spec.js
+++ b/test/get.spec.js
@@ -23,7 +23,7 @@ describe('.get (specific go-ipfs features)', function () {
 
   const smallFile = {
     cid: 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP',
-    data: fixture('js/test/fixtures/testfile.txt')
+    data: fixture('test/fixtures/testfile.txt')
   }
 
   let ipfsd


### PR DESCRIPTION
Hi :-)  
following up on an issue in [interface-js-ipfs-core](https://github.com/ipfs/interface-js-ipfs-core/issues/436) I'm creating this PR. 
Also created PR in [js-libp2p](https://github.com/libp2p/js-libp2p/pull/321) accordingly. 
This would help in cases like mine where my implementation is not able to support references to a handler function.
I will add the final url in the README to the method documentation once I merge the final PR `to interface-js-ipfs-core` since its pointing nowhere now. 

**Edit:** 

Opened a [PR](https://github.com/ipfs/interface-js-ipfs-core/pull/437) on `interface-js-ipfs-core`