### PR TITLE
perf: use test profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "^7.11.1",
     "go-ipfs-dep": "~0.4.18",
     "interface-ipfs-core": "~0.96.0",
-    "ipfsd-ctl": "~0.40.0",
+    "ipfsd-ctl": "github:ipfs/js-ipfsd-ctl#feat/support-profile",
     "nock": "^10.0.2",
     "pull-stream": "^3.6.9",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-react": "^7.11.1",
     "go-ipfs-dep": "~0.4.18",
     "interface-ipfs-core": "~0.96.0",
-    "ipfsd-ctl": "github:ipfs/js-ipfsd-ctl#feat/support-profile",
+    "ipfsd-ctl": "github:ipfs/js-ipfsd-ctl",
     "nock": "^10.0.2",
     "pull-stream": "^3.6.9",
     "stream-equal": "^1.1.1"

--- a/test/commands.spec.js
+++ b/test/commands.spec.js
@@ -17,7 +17,7 @@ describe('.commands', function () {
   let ipfs
 
   before((done) => {
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -84,7 +84,7 @@ describe('ipfs-http-client constructor tests', () => {
     before(function (done) {
       this.timeout(60 * 1000) // slow CI
 
-      f.spawn({ initOptions: { bits: 1024 } }, (err, node) => {
+      f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, node) => {
         expect(err).to.not.exist()
         ipfsd = node
         apiAddr = node.apiAddr.toString()

--- a/test/custom-headers.spec.js
+++ b/test/custom-headers.spec.js
@@ -18,7 +18,7 @@ describe('custom headers', function () {
   let ipfsd
   // initialize ipfs with custom headers
   before(done => {
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient({

--- a/test/dag.spec.js
+++ b/test/dag.spec.js
@@ -21,7 +21,7 @@ describe('.dag', function () {
   this.timeout(20 * 1000)
   before(function (done) {
     series([
-      (cb) => f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+      (cb) => f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
         expect(err).to.not.exist()
         ipfsd = _ipfsd
         ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/diag.spec.js
+++ b/test/diag.spec.js
@@ -20,7 +20,7 @@ describe('.diag', function () {
   let ipfs
 
   before((done) => {
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/files-mfs.spec.js
+++ b/test/files-mfs.spec.js
@@ -38,7 +38,7 @@ describe('.files (the MFS API part)', function () {
   const expectedMultihash = 'Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP'
 
   before((done) => {
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/get.spec.js
+++ b/test/get.spec.js
@@ -31,7 +31,7 @@ describe('.get (specific go-ipfs features)', function () {
 
   before(function (done) {
     series([
-      (cb) => f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+      (cb) => f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
         expect(err).to.not.exist()
         ipfsd = _ipfsd
         ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/key.spec.js
+++ b/test/key.spec.js
@@ -17,7 +17,7 @@ describe('.key', function () {
   let ipfs
 
   before((done) => {
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -17,7 +17,7 @@ describe('.log', function () {
   let ipfs
 
   before((done) => {
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/name.spec.js
+++ b/test/name.spec.js
@@ -28,7 +28,7 @@ describe('.name', () => {
 
     series([
       (cb) => {
-        f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+        f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
           expect(err).to.not.exist()
           ipfsd = _ipfsd
           ipfs = ipfsClient(_ipfsd.apiAddr)
@@ -36,7 +36,7 @@ describe('.name', () => {
         })
       },
       (cb) => {
-        f.spawn({ initOptions: { bits: 1024 } }, (err, node) => {
+        f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, node) => {
           expect(err).to.not.exist()
           other = node.api
           otherd = node

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -34,7 +34,7 @@ describe('.ping', function () {
 
     series([
       (cb) => {
-        f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+        f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
           expect(err).to.not.exist()
           ipfsd = _ipfsd
           ipfs = ipfsClient(_ipfsd.apiAddr)
@@ -42,7 +42,7 @@ describe('.ping', function () {
         })
       },
       (cb) => {
-        f.spawn({ initOptions: { bits: 1024 } }, (err, node) => {
+        f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, node) => {
           expect(err).to.not.exist()
           other = node.api
           otherd = node

--- a/test/pubsub-in-browser.spec.js
+++ b/test/pubsub-in-browser.spec.js
@@ -47,7 +47,7 @@ describe('.pubsub is not supported in the browser, yet!', function () {
   let ipfsd
 
   before((done) => {
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/refs.spec.js
+++ b/test/refs.spec.js
@@ -35,7 +35,7 @@ describe('.refs', function () {
     }
 
     waterfall([
-      (cb) => f.spawn({ initOptions: { bits: 1024 } }, cb),
+      (cb) => f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, cb),
       (_ipfsd, cb) => {
         ipfsd = _ipfsd
         ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/repo.spec.js
+++ b/test/repo.spec.js
@@ -16,7 +16,7 @@ describe('.repo', function () {
   let ipfsd
 
   before((done) => {
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/stats.spec.js
+++ b/test/stats.spec.js
@@ -16,7 +16,7 @@ describe('stats', function () {
   let ipfsd
 
   before((done) => {
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -20,7 +20,7 @@ describe('.util', () => {
   before(function (done) {
     this.timeout(20 * 1000) // slow CI
 
-    f.spawn({ initOptions: { bits: 1024 } }, (err, _ipfsd) => {
+    f.spawn({ initOptions: { bits: 1024, profile: 'test' } }, (err, _ipfsd) => {
       expect(err).to.not.exist()
       ipfsd = _ipfsd
       ipfs = ipfsClient(_ipfsd.apiAddr)

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -9,7 +9,7 @@ function createFactory (options) {
   options = options || {}
 
   options.factoryOptions = options.factoryOptions || {}
-  options.spawnOptions = options.spawnOptions || { initOptions: { bits: 1024 } }
+  options.spawnOptions = options.spawnOptions || { initOptions: { bits: 1024, profile: 'test' } }
 
   const ipfsFactory = IPFSFactory.create(options.factoryOptions)
 


### PR DESCRIPTION
Urh, this is kind of amazing, it took the node.js test time down from 13m49.208s to 5m15.992s 😱 (for me locally)

For reference, this is what using the "test" profile does: https://github.com/ipfs/go-ipfs-config/blob/master/profile.go#L68-L85

resolves https://github.com/ipfs/js-ipfs-http-client/issues/593

Depends on:

* [x] https://github.com/ipfs/js-ipfsd-ctl/pull/321