### PR TITLE
fix multipart/form-data

### DIFF
--- a/src/utils/send-files-stream.js
+++ b/src/utils/send-files-stream.js
@@ -7,12 +7,12 @@ const once = require('once')
 const prepareFile = require('./prepare-file')
 const Multipart = require('./multipart')
 
-function headers (file) {
-  const name = file.path
+function headers (file, i) {
+  const filename = file.path
     ? encodeURIComponent(file.path)
     : ''
 
-  const header = { 'Content-Disposition': `file; filename="${name}"` }
+  const header = { 'Content-Disposition': `form-data; name="data${i}"; filename="${filename}"` }
 
   if (!file.content) {
     header['Content-Type'] = 'application/x-directory'
@@ -43,7 +43,7 @@ module.exports = (send, path) => {
       const next = once(_next)
       try {
         const files = prepareFile(file, options)
-          .map((file) => Object.assign({ headers: headers(file) }, file))
+          .map((file, i) => Object.assign({ headers: headers(file, i) }, file))
 
         writing = true
         eachSeries(


### PR DESCRIPTION
This PR is the counterpart of https://github.com/ipfs/go-ipfs-files/pull/8

According to https://tools.ietf.org/html/rfc7578#section-4.2, in a Content-Disposition header
of a part in a multipart/form-data body:

- the disposition must be of type `form-data`
- a `name` parameter (not explicitely specified by the RFC, but I suppose non-empty)

As this `name` parameter is unused by IPFS, this commit simply generate a placeholder with
a counter, to conform to the HTTP specification.

I couldn't test properly that this fix actually works properly, so please test thoroughly. 