### PR TITLE
fix: dht.findProvs.js handle valid hash but no providers

### DIFF
--- a/src/dht/findprovs.js
+++ b/src/dht/findprovs.js
@@ -23,6 +23,12 @@ module.exports = (send) => {
     }
 
     const handleResult = (res, callback) => {
+      // callback with an empty array if no providers are found
+      if (!res) {
+        const responses = []
+        return callback(null, responses)
+      }
+
       // Inconsistent return values in the browser vs node
       if (Array.isArray(res)) {
         res = res[0]


### PR DESCRIPTION
This is a fix for #928 
