### PR TITLE
Fix support for /https multiaddrs passed to constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "is-ipfs": "~0.6.0",
     "is-pull-stream": "0.0.0",
     "is-stream": "^1.1.0",
-    "iso-stream-http": "~0.1.1",
+    "iso-stream-http": "~0.1.2",
     "iso-url": "~0.4.6",
     "just-kebab-case": "^1.1.0",
     "just-map-keys": "^1.1.0",

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -30,7 +30,25 @@ describe('ipfs-http-client constructor tests', () => {
       expectConfig(ipfs, { host, port, protocol })
     })
 
-    it('mutliaddr dns4 string, opts', () => {
+    it('multiaddr dns4 string (implicit http)', () => {
+      const host = 'foo.com'
+      const port = '1001'
+      const protocol = 'http' // default to http if not specified in multiaddr
+      const addr = `/dns4/${host}/tcp/${port}`
+      const ipfs = ipfsClient(addr)
+      expectConfig(ipfs, { host, port, protocol })
+    })
+
+    it('multiaddr dns4 string (explicit https)', () => {
+      const host = 'foo.com'
+      const port = '1001'
+      const protocol = 'https'
+      const addr = `/dns4/${host}/tcp/${port}/${protocol}`
+      const ipfs = ipfsClient(addr)
+      expectConfig(ipfs, { host, port, protocol })
+    })
+
+    it('multiaddr dns4 string, explicit https in opts', () => {
       const host = 'foo.com'
       const port = '1001'
       const protocol = 'https'
@@ -39,15 +57,25 @@ describe('ipfs-http-client constructor tests', () => {
       expectConfig(ipfs, { host, port, protocol })
     })
 
-    it('mutliaddr ipv4 string', () => {
+    it('multiaddr ipv4 string (implicit http)', () => {
       const host = '101.101.101.101'
       const port = '1001'
+      const protocol = 'http'
       const addr = `/ip4/${host}/tcp/${port}`
       const ipfs = ipfsClient(addr)
-      expectConfig(ipfs, { host, port })
+      expectConfig(ipfs, { host, port, protocol })
     })
 
-    it('mutliaddr instance', () => {
+    it('multiaddr ipv4 string (explicit https)', () => {
+      const host = '101.101.101.101'
+      const port = '1001'
+      const protocol = 'https'
+      const addr = `/ip4/${host}/tcp/${port}/${protocol}`
+      const ipfs = ipfsClient(addr)
+      expectConfig(ipfs, { host, port, protocol })
+    })
+
+    it('multiaddr instance', () => {
       const host = 'ace.place'
       const port = '1001'
       const addr = multiaddr(`/dns4/${host}/tcp/${port}`)
@@ -70,7 +98,7 @@ describe('ipfs-http-client constructor tests', () => {
       expectConfig(ipfs, { host, port, apiPath })
     })
 
-    it('throws on invalid mutliaddr', () => {
+    it('throws on invalid multiaddr', () => {
       expect(() => ipfsClient('/dns4')).to.throw('invalid address')
       expect(() => ipfsClient('/hello')).to.throw('no protocol with name')
       expect(() => ipfsClient('/dns4/ipfs.io')).to.throw('multiaddr must have a valid format')


### PR DESCRIPTION
## Bug

Pointing Web UI at `/https` multiaddr did not work: it was not able to connect to API over HTTPS, always tried HTTP (https://github.com/ipfs-shipyard/ipfs-webui/issues/989):

> ![](https://user-images.githubusercontent.com/157609/55738075-aaa97480-5a26-11e9-945d-12a53b943326.png) 

I tracked the bug up to `ipfs-http-client` constructor: only `host` and `port` were read from multiaddr, `protocol` was ignored and unencrypted HTTP was used for all multiaddrs:
https://github.com/ipfs/js-ipfs-http-client/blob/21cdcc5100b32e3ac1e75ec70022b9b28b0aede1/src/index.js#L27-L28

## Fix


This PR:

- improves parsing of multiaddr constructor parameter
- adds tests to ensure HTTPS is respected in all scenarios
- updates iso-stream-http to v0.1.2 which includes unrelated fix for "https does not exist" error

