### PR TITLE
fix: fix missing buffer bundling with browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bignumber.js": "^8.0.2",
     "bl": "^3.0.0",
     "bs58": "^4.0.1",
+    "buffer": "^5.2.1",
     "cids": "~0.5.5",
     "concat-stream": "hugomrdias/concat-stream#feat/smaller",
     "debug": "^4.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 /* global self */
 
 const isIPFS = require('is-ipfs')
+const { Buffer } = require('buffer')
 const CID = require('cids')
 const multiaddr = require('multiaddr')
 const multibase = require('multibase')


### PR DESCRIPTION
Closes #964

We should backport this to js-ipfs.

Explicit require of buffer can actually be enforce by linter to avoid these and other issues with node/browser stuff.