### PR TITLE
fix: Uncaught Error when adding files bigger than 1MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "promisify-es6": "^1.0.3",
     "pull-defer": "~0.2.3",
     "pull-stream": "^3.6.9",
-    "pull-to-stream": "~0.1.0",
+    "pull-to-stream": "~0.1.1",
     "pump": "^3.0.0",
     "qs": "^6.5.2",
     "readable-stream": "^3.1.1",


### PR DESCRIPTION
This switches pull-to-stream to v0.1.1 which includes a fix `Uncaught Error: stream.push() after EOF` and truly closes #967 in all build pipelines (semver seems to be  not enough when yarn lockfile is used)