### PR TITLE
GC endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "cross-env": "^5.2.0",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.21",
-    "interface-ipfs-core": "~0.105.0",
+    "interface-ipfs-core": "~0.106.0",
     "ipfsd-ctl": "~0.43.0",
     "nock": "^10.0.2",
     "stream-equal": "^1.1.1"

--- a/src/repo/gc.js
+++ b/src/repo/gc.js
@@ -2,11 +2,12 @@
 
 const promisify = require('promisify-es6')
 const streamToValueWithTransformer = require('../utils/stream-to-value-with-transformer')
+const CID = require('cids')
 
 const transform = function (res, callback) {
   callback(null, res.map(r => ({
-    err: r.Err,
-    cid: (r.Key || {})['/']
+    err: r.Err ? new Error(r.Err) : null,
+    cid: r.Key ? new CID(r.Key) : null
   })))
 }
 

--- a/src/repo/gc.js
+++ b/src/repo/gc.js
@@ -7,7 +7,7 @@ const CID = require('cids')
 const transform = function (res, callback) {
   callback(null, res.map(r => ({
     err: r.Err ? new Error(r.Err) : null,
-    cid: r.Key ? new CID(r.Key) : null
+    cid: (r.Key || {})['/'] ? new CID(r.Key['/']) : null
   })))
 }
 


### PR DESCRIPTION
BREAKING CHANGE: repo.gc response objects have changed to `{ err, cid }`

Depends on:

* [x] https://github.com/ipfs/interface-js-ipfs-core/pull/462