### PR TITLE
build: change min node version to 8.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ stages:
 
 node_js:
   - '10'
+  - '8'
 
 os:
   - linux

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "through2": "^3.0.1"
   },
   "engines": {
-    "node": ">=10.0.0",
+    "node": ">=8.3.0",
     "npm": ">=3.0.0"
   },
   "repository": {


### PR DESCRIPTION
Also adjust Travis CI config to perform builds and tests with node 8.

`npm install`, `npm run build`, and `npm run test` all succeeded locally with node version `8.3.0`.

The reason for version `8.3.0` instead of `8.0.0` is that `8.3.0` introduced support for object rest/spread, which is used by at least one of this package's devDependencies (`go-ipfs-dep`, in production install of that devDep). It may be the case that at runtime older versions of node would work correctly with the built package, but it seems simpler to settle on the minimum supported version being a version that can build, test, and use the package.

Closes #983.