### PR TITLE
JSON.parse error reporting: with `invalid json:` in the error string

### DIFF
--- a/src/utils/send-request.js
+++ b/src/utils/send-request.js
@@ -32,7 +32,7 @@ function parseError (res, cb) {
       cb(error)
     })
   }
-  
+
   streamToJsonValue(res, (err, payload) => {
     if (err) {
       return cb(err)

--- a/src/utils/send-request.js
+++ b/src/utils/send-request.js
@@ -29,6 +29,7 @@ function parseError (res, cb) {
       if (data && data.length) {
         error.message = data.toString()
       }
+      error.code = res.statusCode
       cb(error)
     })
   }

--- a/src/utils/send-request.js
+++ b/src/utils/send-request.js
@@ -21,7 +21,7 @@ function parseError (res, cb, isJson = true) {
       // the `err` here refers to errors in stream processing, which
       // we ignore here, since we already have a valid `error` response
       // from the server above that we have to report to the caller.
-      if (data) {
+      if (data && data.length) {
         error.message = data.toString()
       }
       cb(error)

--- a/src/utils/stream-to-json-value.js
+++ b/src/utils/stream-to-json-value.js
@@ -24,7 +24,7 @@ function streamToJsonValue (res, cb) {
     try {
       res = JSON.parse(data)
     } catch (err) {
-      return cb(err)
+      return cb(new Error(`Invalid JSON: ${data}`))
     }
 
     cb(null, res)


### PR DESCRIPTION
Better error reporting in case of `json.parse` failures

resolves #912
resolves #1000