### PR TITLE
JSON.parse error reporting: without `invalid json:` in the error string

### DIFF
--- a/src/utils/stream-to-json-value.js
+++ b/src/utils/stream-to-json-value.js
@@ -24,7 +24,7 @@ function streamToJsonValue (res, cb) {
     try {
       res = JSON.parse(data)
     } catch (err) {
-      return cb(err)
+      return cb(new Error(data))
     }
 
     cb(null, res)


### PR DESCRIPTION
Better Error reporting for `json.parse` errors with `data` in the error