### PR TITLE
Handle Empty Array return values for findProvs method

### DIFF
--- a/src/dht/findprovs.js
+++ b/src/dht/findprovs.js
@@ -23,15 +23,15 @@ module.exports = (send) => {
     }
 
     const handleResult = (res, callback) => {
+      // Inconsistent return values in the browser vs node
+      if (Array.isArray(res)) {
+        res = res[0]
+      }
+      
       // callback with an empty array if no providers are found
       if (!res) {
         const responses = []
         return callback(null, responses)
-      }
-
-      // Inconsistent return values in the browser vs node
-      if (Array.isArray(res)) {
-        res = res[0]
       }
 
       // Type 4 keys


### PR DESCRIPTION
Correcting the array check to happen before the individual element checks. fixes https://github.com/ipfs/js-ipfs-http-client/issues/928