### PR TITLE
fix: actually send the param to trigger the trickle dag builder

### DIFF
--- a/src/utils/send-files-stream.js
+++ b/src/utils/send-files-stream.js
@@ -81,6 +81,10 @@ module.exports = (send, path) => {
     qs['wrap-with-directory'] = propOrProp(options, 'wrap-with-directory', 'wrapWithDirectory')
     qs.hash = propOrProp(options, 'hash', 'hashAlg')
 
+    if (options.strategy === 'trickle' || options.trickle) {
+      qs['trickle'] = 'true'
+    }
+
     const args = {
       path: path,
       qs: qs,


### PR DESCRIPTION
Looks like this was missed off..