### PR TITLE
chore: update min bundlesize

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -5,7 +5,7 @@ const createServer = require('ipfsd-ctl').createServer
 const server = createServer()
 
 module.exports = {
-  bundlesize: { maxSize: '232kB' },
+  bundlesize: { maxSize: '236kB' },
   webpack: {
     resolve: {
       mainFields: ['browser', 'main']


### PR DESCRIPTION
We added some functionality and made it a tiny bit bigger, sorry. This will hopefully come down again when we switch to async await and async iterators.