### PR TITLE
Allow all opts for cmd:cat, to support the timeout flag

### DIFF
--- a/src/files-regular/cat.js
+++ b/src/files-regular/cat.js
@@ -20,12 +20,7 @@ module.exports = (send) => {
       }
     }
 
-    const query = {
-      offset: opts.offset,
-      length: opts.length
-    }
-
-    send({ path: 'cat', args: hash, buffer: opts.buffer, qs: query }, (err, stream) => {
+    send({ path: 'cat', args: hash, buffer: opts.buffer, qs: opts }, (err, stream) => {
       if (err) { return callback(err) }
 
       stream.pipe(bl((err, data) => {


### PR DESCRIPTION
I need the timeout flag for my application, but I recognized that `js-ipfs-http-client` does not allow it for the command `cat`. I modified that file such that it forwards the opts as it is done by the `get` command. 

With this call it would be possible to set the a timeout for the ```cat``` command.

```ipfsClient.cat(`/ipfs/${YOUR_HASH}`,{timeout: '10s'}, callback)```




