### PR TITLE
fix: sometimes no Addrs element is present in the response

### DIFF
--- a/src/dht/findprovs.js
+++ b/src/dht/findprovs.js
@@ -44,11 +44,13 @@ module.exports = (send) => {
       const responses = res.Responses.map((r) => {
         const peerInfo = new PeerInfo(PeerId.createFromB58String(r.ID))
 
-        r.Addrs.forEach((addr) => {
-          const ma = multiaddr(addr)
+        if (r.Addrs) {
+          r.Addrs.forEach((addr) => {
+            const ma = multiaddr(addr)
 
-          peerInfo.multiaddrs.add(ma)
-        })
+            peerInfo.multiaddrs.add(ma)
+          })
+        }
 
         return peerInfo
       })


### PR DESCRIPTION
I'm not sure why this is the case, but sometimes go returns no `.Addrs` property in the `dht.findProvs` response.