### PR TITLE
fix: response for findpeer and findprovs

### DIFF
--- a/src/dht/findpeer.js
+++ b/src/dht/findpeer.js
@@ -6,7 +6,7 @@ const streamToValueWithTransformer = require('../utils/stream-to-value-with-tran
 const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const errcode = require('error-code')
+const errcode = require('err-code')
 
 module.exports = (send) => {
   return promisify((peerId, opts, callback) => {

--- a/src/dht/findpeer.js
+++ b/src/dht/findpeer.js
@@ -28,6 +28,8 @@ module.exports = (send) => {
       }
 
       // Type 2 keys
+      // 2 = FinalPeer
+      // https://github.com/libp2p/go-libp2p-core/blob/6e566d10f4a5447317a66d64c7459954b969bdab/routing/query.go#L18
       if (!res || res.Type !== 2) {
         return callback()
       }

--- a/src/dht/findpeer.js
+++ b/src/dht/findpeer.js
@@ -6,6 +6,7 @@ const streamToValueWithTransformer = require('../utils/stream-to-value-with-tran
 const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
+const errcode = require('error-code')
 
 module.exports = (send) => {
   return promisify((peerId, opts, callback) => {
@@ -31,7 +32,8 @@ module.exports = (send) => {
       // 2 = FinalPeer
       // https://github.com/libp2p/go-libp2p-core/blob/6e566d10f4a5447317a66d64c7459954b969bdab/routing/query.go#L18
       if (!res || res.Type !== 2) {
-        return callback()
+        const errMsg = `key was not found (type 4)`
+        return callback(errcode(new Error(errMsg), 'ERR_KEY_TYPE_4_NOT_FOUND'))
       }
 
       const responseReceived = res.Responses[0]

--- a/src/dht/findpeer.js
+++ b/src/dht/findpeer.js
@@ -46,7 +46,7 @@ module.exports = (send) => {
 
     send({
       path: 'dht/findpeer',
-      args: peerId,
+      args: peerId.toString(),
       qs: opts
     }, (err, result) => {
       if (err) {

--- a/src/dht/findpeer.js
+++ b/src/dht/findpeer.js
@@ -6,7 +6,6 @@ const streamToValueWithTransformer = require('../utils/stream-to-value-with-tran
 const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const errcode = require('err-code')
 
 module.exports = (send) => {
   return promisify((peerId, opts, callback) => {
@@ -25,14 +24,12 @@ module.exports = (send) => {
     const handleResult = (res, callback) => {
       // Inconsistent return values in the browser
       if (Array.isArray(res)) {
-        res = res[0]
+        res = res.find(r => r.Type === 2)
       }
 
       // Type 2 keys
-      if (res.Type !== 2) {
-        const errMsg = `key was not found (type 2)`
-
-        return callback(errcode(new Error(errMsg), 'ERR_KEY_TYPE_2_NOT_FOUND'))
+      if (!res || res.Type !== 2) {
+        return callback()
       }
 
       const responseReceived = res.Responses[0]

--- a/src/dht/findprovs.js
+++ b/src/dht/findprovs.js
@@ -6,7 +6,6 @@ const streamToValueWithTransformer = require('../utils/stream-to-value-with-tran
 const multiaddr = require('multiaddr')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const errcode = require('err-code')
 
 module.exports = (send) => {
   return promisify((cid, opts, callback) => {
@@ -25,20 +24,12 @@ module.exports = (send) => {
     const handleResult = (res, callback) => {
       // Inconsistent return values in the browser vs node
       if (Array.isArray(res)) {
-        res = res[0]
+        res = res.find(r => r.Type === 4)
       }
 
       // callback with an empty array if no providers are found
-      if (!res) {
-        const responses = []
-        return callback(null, responses)
-      }
-
-      // Type 4 keys
-      if (res.Type !== 4) {
-        const errMsg = `key was not found (type 4)`
-
-        return callback(errcode(new Error(errMsg), 'ERR_KEY_TYPE_4_NOT_FOUND'))
+      if (!res || res.Type !== 4) {
+        return callback(null, [])
       }
 
       const responses = res.Responses.map((r) => {

--- a/src/dht/findprovs.js
+++ b/src/dht/findprovs.js
@@ -28,6 +28,8 @@ module.exports = (send) => {
       }
 
       // callback with an empty array if no providers are found
+      // 4 = Provider
+      // https://github.com/libp2p/go-libp2p-core/blob/6e566d10f4a5447317a66d64c7459954b969bdab/routing/query.go#L20
       if (!res || res.Type !== 4) {
         return callback(null, [])
       }

--- a/src/dht/findprovs.js
+++ b/src/dht/findprovs.js
@@ -51,7 +51,7 @@ module.exports = (send) => {
 
     send({
       path: 'dht/findprovs',
-      args: cid,
+      args: cid.toString(),
       qs: opts
     }, (err, result) => {
       if (err) {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -92,6 +92,10 @@ describe('interface-ipfs-core tests', () => {
         name: 'should provide from one node and find it through another node',
         reason: 'FIXME go-ipfs endpoint doesn\'t conform with the others https://github.com/ipfs/go-ipfs/issues/5047'
       },
+      {
+        name: 'should take options to override timeout config',
+        reason: 'FIXME go-ipfs does not support a timeout option'
+      },
       // dht.get
       {
         name: 'should get a value after it was put on another node',


### PR DESCRIPTION
Pick out the correct item from the response, do not assume the first is the one we want.

Also calls `toString` on the CID/PeerID so that we can pass CID instances directly to these functions.