### PR TITLE
fix: make findprovs return all responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "cross-env": "^5.2.0",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.21",
-    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#test/many-providers",
+    "interface-ipfs-core": "~0.107.0",
     "ipfsd-ctl": "~0.43.0",
     "nock": "^10.0.2",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "cross-env": "^5.2.0",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.21",
-    "interface-ipfs-core": "~0.106.0",
+    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#test/many-providers",
     "ipfsd-ctl": "~0.43.0",
     "nock": "^10.0.2",
     "stream-equal": "^1.1.1"

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -89,10 +89,6 @@ describe('interface-ipfs-core tests', () => {
       },
       // dht.findprovs
       {
-        name: 'should provide from one node and find it through another node',
-        reason: 'FIXME go-ipfs endpoint doesn\'t conform with the others https://github.com/ipfs/go-ipfs/issues/5047'
-      },
-      {
         name: 'should take options to override timeout config',
         reason: 'FIXME go-ipfs does not support a timeout option'
       },


### PR DESCRIPTION
Find providers was not consistently returning all of the provider responses. This was causing flakey test failures for https://github.com/libp2p/js-libp2p-delegated-content-routing/pull/9.

It will now properly return all response records for each result. 

* [x] requires https://github.com/ipfs/interface-js-ipfs-core/pull/493