### PR TITLE
Added opts to object stat command

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "cross-env": "^5.2.0",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.21",
-    "interface-ipfs-core": "^0.107.1",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#fix/resolve-ipns-test",
     "ipfsd-ctl": "~0.43.0",
     "nock": "^10.0.2",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "cross-env": "^5.2.0",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.21",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#fix/resolve-ipns-test",
+    "interface-ipfs-core": "^0.109.0",
     "ipfsd-ctl": "~0.43.0",
     "nock": "^10.0.2",
     "stream-equal": "^1.1.1"

--- a/src/object/stat.js
+++ b/src/object/stat.js
@@ -21,7 +21,8 @@ module.exports = (send) => {
 
     send({
       path: 'object/stat',
-      args: cid.toString()
+      args: cid.toString(),
+      qs: opts
     }, callback)
   })
 }

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -182,7 +182,14 @@ describe('interface-ipfs-core tests', () => {
     ]
   })
 
-  tests.filesMFS(defaultCommonFactory)
+  tests.filesMFS(defaultCommonFactory, {
+    skip: [
+      {
+        name: 'should ls directory with long option',
+        reason: 'TODO unskip when go-ipfs supports --long https://github.com/ipfs/go-ipfs/pull/6528'
+      }
+    ]
+  })
 
   tests.key(defaultCommonFactory, {
     skip: [

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -49,6 +49,11 @@ describe('interface-ipfs-core tests', () => {
       {
         name: 'replace',
         reason: 'FIXME Waiting for fix on go-ipfs https://github.com/ipfs/js-ipfs-http-client/pull/307#discussion_r69281789 and https://github.com/ipfs/go-ipfs/issues/2927'
+      },
+      // config.profile
+      {
+        name: 'profile',
+        reason: 'TODO not yet implemented https://github.com/ipfs/js-ipfs-http-client/pull/1030'
       }
     ]
   })


### PR DESCRIPTION
The ipfs object stat command couldn't handle the {timeout: '1s'} option (or any other options). We're already checking for the opts parameter so it makes sense that we should be sending it as well. 

Things work as desired now with this one line addition.

Depends on:

* [x] https://github.com/ipfs/interface-js-ipfs-core/pull/506