### PR TITLE
chore: silence greenkeeper in examples

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -4,15 +4,6 @@
       "packages": [
         "package.json"
       ]
-    },
-    "examples": {
-      "packages": [
-        "examples/bundle-browserify/package.json",
-        "examples/bundle-webpack/package.json",
-        "examples/name-api/package.json",
-        "examples/sub-module/package.json",
-        "examples/upload-file-via-browser/package.json"
-      ]
     }
   }
 }


### PR DESCRIPTION
Too much greenkeeper noise and they are not critical to the project.