### PR TITLE
feat: support adding files via async iterator

### DIFF
--- a/src/files-regular/add-async-iterator.js
+++ b/src/files-regular/add-async-iterator.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const SendFilesStream = require('../utils/send-files-stream')
+const FileResultStreamConverter = require('../utils/file-result-stream-converter')
+
+module.exports = (send) => {
+  return async function * (source, options) {
+    options = options || {}
+    options.converter = FileResultStreamConverter
+
+    const stream = SendFilesStream(send, 'add')(options)
+
+    for await (const entry of source) {
+      stream.write(entry)
+    }
+
+    stream.end()
+
+    for await (const entry of stream) {
+      yield entry
+    }
+  }
+}

--- a/src/files-regular/index.js
+++ b/src/files-regular/index.js
@@ -12,6 +12,7 @@ module.exports = (arg) => {
     addFromFs: require('../files-regular/add-from-fs')(send),
     addFromURL: require('../files-regular/add-from-url')(send),
     addFromStream: require('../files-regular/add')(send),
+    _addAsyncIterator: require('../files-regular/add-async-iterator')(send),
     cat: require('../files-regular/cat')(send),
     catReadableStream: require('../files-regular/cat-readable-stream')(send),
     catPullStream: require('../files-regular/cat-pull-stream')(send),

--- a/src/utils/load-commands.js
+++ b/src/utils/load-commands.js
@@ -9,6 +9,7 @@ function requireCommands () {
     addFromFs: require('../files-regular/add-from-fs'),
     addFromURL: require('../files-regular/add-from-url'),
     addFromStream: require('../files-regular/add'),
+    _addAsyncIterator: require('../files-regular/add-async-iterator'),
     cat: require('../files-regular/cat'),
     catReadableStream: require('../files-regular/cat-readable-stream'),
     catPullStream: require('../files-regular/cat-pull-stream'),


### PR DESCRIPTION
Adds a method called `ipfs._addAsyncIterator`, prefixed with an underscore to mark it as sort of unofficial (though it's what `ipfs.add` will become once the async iterator migration is complete) and we don't want to implement symmetrical `ipfs.catAsyncIterator` etc methods, or at least not yet.

Also adds support for sending the `pin` and (non-standard, JS-specific) `preload` arguments via HTTP.