### PR TITLE
chore: update multiaddrs module

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ky": "^0.13.0",
     "ky-universal": "^0.3.0",
     "lru-cache": "^5.1.1",
-    "multiaddr": "^6.0.6",
+    "multiaddr": "^7.1.0",
     "multibase": "~0.6.0",
     "multicodec": "~0.5.1",
     "multihashes": "~0.4.14",

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -24,7 +24,7 @@ describe('ipfs-http-client constructor tests', () => {
 
     it('opts', () => {
       const host = 'wizard.world'
-      const port = '999'
+      const port = 999
       const protocol = 'https'
       const ipfs = ipfsClient({ host, port, protocol })
       expectConfig(ipfs, { host, port, protocol })
@@ -32,7 +32,7 @@ describe('ipfs-http-client constructor tests', () => {
 
     it('multiaddr dns4 string (implicit http)', () => {
       const host = 'foo.com'
-      const port = '1001'
+      const port = 1001
       const protocol = 'http' // default to http if not specified in multiaddr
       const addr = `/dns4/${host}/tcp/${port}`
       const ipfs = ipfsClient(addr)
@@ -41,7 +41,7 @@ describe('ipfs-http-client constructor tests', () => {
 
     it('multiaddr dns4 string (explicit https)', () => {
       const host = 'foo.com'
-      const port = '1001'
+      const port = 1001
       const protocol = 'https'
       const addr = `/dns4/${host}/tcp/${port}/${protocol}`
       const ipfs = ipfsClient(addr)
@@ -50,7 +50,7 @@ describe('ipfs-http-client constructor tests', () => {
 
     it('multiaddr dns4 string, explicit https in opts', () => {
       const host = 'foo.com'
-      const port = '1001'
+      const port = 1001
       const protocol = 'https'
       const addr = `/dns4/${host}/tcp/${port}`
       const ipfs = ipfsClient(addr, { protocol })
@@ -59,7 +59,7 @@ describe('ipfs-http-client constructor tests', () => {
 
     it('multiaddr ipv4 string (implicit http)', () => {
       const host = '101.101.101.101'
-      const port = '1001'
+      const port = 1001
       const protocol = 'http'
       const addr = `/ip4/${host}/tcp/${port}`
       const ipfs = ipfsClient(addr)
@@ -68,7 +68,7 @@ describe('ipfs-http-client constructor tests', () => {
 
     it('multiaddr ipv4 string (explicit https)', () => {
       const host = '101.101.101.101'
-      const port = '1001'
+      const port = 1001
       const protocol = 'https'
       const addr = `/ip4/${host}/tcp/${port}/${protocol}`
       const ipfs = ipfsClient(addr)
@@ -77,7 +77,7 @@ describe('ipfs-http-client constructor tests', () => {
 
     it('multiaddr instance', () => {
       const host = 'ace.place'
-      const port = '1001'
+      const port = 1001
       const addr = multiaddr(`/dns4/${host}/tcp/${port}`)
       const ipfs = ipfsClient(addr)
       expectConfig(ipfs, { host, port })
@@ -85,14 +85,14 @@ describe('ipfs-http-client constructor tests', () => {
 
     it('host and port strings', () => {
       const host = '1.1.1.1'
-      const port = '9999'
+      const port = 9999
       const ipfs = ipfsClient(host, port)
       expectConfig(ipfs, { host, port })
     })
 
     it('host, port and api path', () => {
       const host = '10.100.100.255'
-      const port = '9999'
+      const port = 9999
       const apiPath = '/future/api/v1/'
       const ipfs = ipfsClient(host, port, { 'api-path': apiPath })
       expectConfig(ipfs, { host, port, apiPath })

--- a/test/node/swarm.js
+++ b/test/node/swarm.js
@@ -48,7 +48,7 @@ describe('.swarm.peers', function () {
     expect(res).to.be.a('array')
     expect(res.length).to.equal(1)
     expect(res[0].error).to.not.exist()
-    expect(res[0].addr.toString()).to.equal('/ip4/73.109.217.59/tcp/49311/ipfs/QmWjxEGC7BthJrCf7QTModrcsRweHbupdPTY4oGMVoDZXm')
+    expect(res[0].addr.toString()).to.equal('/ip4/73.109.217.59/tcp/49311/p2p/QmWjxEGC7BthJrCf7QTModrcsRweHbupdPTY4oGMVoDZXm')
     expect(res[0].peer.toB58String()).to.equal('QmWjxEGC7BthJrCf7QTModrcsRweHbupdPTY4oGMVoDZXm')
     expect(scope.isDone()).to.equal(true)
   })


### PR DESCRIPTION
Needed to fix the `js-ipfs` build because `mafmt` upgraded to `multiaddrs@7` in a patch release while `js-ipfs` and friends depend on `multiaddrs@6` so now `mafmt.isIPFS` fails when passed a v6 multiaddr instance.

Yay, classes in JavaScript.