### PR TITLE
fix: fix electron renderer tests and a couple more bugs

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,9 +1,13 @@
 'use strict'
 
+const promisify = require('promisify-es6')
 const createServer = require('ipfsd-ctl').createServer
-
+const EchoServer = require('interface-ipfs-core/src/utils/echo-http-server')
 const server = createServer()
+const echoServer = EchoServer.createServer()
 
+const echoServeStart = promisify(echoServer.start)
+const echoServeStop = promisify(echoServer.stop)
 module.exports = {
   bundlesize: { maxSize: '245kB' },
   webpack: {
@@ -22,9 +26,24 @@ module.exports = {
     singleRun: true
   },
   hooks: {
+    node: {
+      pre: () => echoServeStart(),
+      post: () => echoServeStop()
+    },
     browser: {
-      pre: () => server.start(),
-      post: () => server.stop()
+      pre: () => {
+        return Promise.all([
+          server.start(),
+          echoServeStart()
+
+        ])
+      },
+      post: () => {
+        return Promise.all([
+          server.stop(),
+          echoServeStop()
+        ])
+      }
     }
   }
 }

--- a/.aegir.js
+++ b/.aegir.js
@@ -35,7 +35,6 @@ module.exports = {
         return Promise.all([
           server.start(),
           echoServerStart()
-
         ])
       },
       post: () => {

--- a/.aegir.js
+++ b/.aegir.js
@@ -6,8 +6,8 @@ const EchoServer = require('interface-ipfs-core/src/utils/echo-http-server')
 const server = createServer()
 const echoServer = EchoServer.createServer()
 
-const echoServeStart = promisify(echoServer.start)
-const echoServeStop = promisify(echoServer.stop)
+const echoServerStart = promisify(echoServer.start)
+const echoServerStop = promisify(echoServer.stop)
 module.exports = {
   bundlesize: { maxSize: '245kB' },
   webpack: {
@@ -27,21 +27,21 @@ module.exports = {
   },
   hooks: {
     node: {
-      pre: () => echoServeStart(),
-      post: () => echoServeStop()
+      pre: () => echoServerStart(),
+      post: () => echoServerStop()
     },
     browser: {
       pre: () => {
         return Promise.all([
           server.start(),
-          echoServeStart()
+          echoServerStart()
 
         ])
       },
       post: () => {
         return Promise.all([
           server.stop(),
-          echoServeStop()
+          echoServerStop()
         ])
       }
     }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
-cache: npm
+# cache: npm
+cache: false
+
 stages:
-  - check
+  # - check
   - test
   - cov
 
@@ -19,11 +21,11 @@ after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codeco
 
 jobs:
   include:
-    - stage: check
-      script:
-        - npx aegir build --bundlesize
-        - npx aegir dep-check
-        - npm run lint
+    # - stage: check
+    #   script:
+    #     - npx aegir build --bundlesize
+    #     - npx aegir dep-check
+    #     - npm run lint
 
     - stage: test
       name: chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 # cache: npm
 cache: false
 stages:
-  - check
+  # - check
   - test
   - cov
 
@@ -20,11 +20,11 @@ after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codeco
 
 jobs:
   include:
-    - stage: check
-      script:
+    # - stage: check
+    #   script:
         # - npx aegir build --bundlesize
         # - npx aegir dep-check
-        - npm run lint
+        # - npm run lint
 
     - stage: test
       name: chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
     - stage: test
       name: electron-renderer
       script:
-        - xvfb-run npx aegir test -t electron-renderer -- --timeout 80000
+        - xvfb-run npx aegir test -t electron-renderer
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
     - stage: test
       name: electron-renderer
       script:
-        - xvfb-run npx aegir test -t electron-renderer -- --bail
+        - xvfb-run npx aegir test -t electron-renderer
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
-# cache: npm
-cache: false
+cache: npm
 stages:
-  # - check
+  - check
   - test
   - cov
 
@@ -20,11 +19,11 @@ after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codeco
 
 jobs:
   include:
-    # - stage: check
-    #   script:
-        # - npx aegir build --bundlesize
-        # - npx aegir dep-check
-        # - npm run lint
+    - stage: check
+      script:
+        - npx aegir build --bundlesize
+        - npx aegir dep-check
+        - npm run lint
 
     - stage: test
       name: chrome
@@ -46,7 +45,7 @@ jobs:
     - stage: test
       name: electron-renderer
       script:
-        - xvfb-run npx aegir test -t electron-renderer
+        - xvfb-run npx aegir test -t electron-renderer -- --bail
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       name: electron-main
       os: osx
       script:
-        - xvfb-run npx aegir test -t electron-main --bail
+        - npx aegir test -t electron-main --bail
 
     - stage: test
       name: electron-renderer

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ stages:
   - cov
 
 node_js:
-  - '10'
   - '12'
+  - '10'
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
 
     - stage: test
       name: electron-main
+      os: osx
       script:
         - xvfb-run npx aegir test -t electron-main --bail
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,6 @@ script: npx nyc -s npm run test:node -- --bail
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 
 jobs:
-  allow_failures:
-    - name: electron-renderer
-
-  fast_finish: true
-
   include:
     - stage: check
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
-# cache: npm
-cache: false
+cache: npm
 
 stages:
-  # - check
+  - check
   - test
   - cov
 
@@ -21,11 +20,11 @@ after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codeco
 
 jobs:
   include:
-    # - stage: check
-    #   script:
-    #     - npx aegir build --bundlesize
-    #     - npx aegir dep-check
-    #     - npm run lint
+    - stage: check
+      script:
+        - npx aegir build --bundlesize
+        - npx aegir dep-check
+        - npm run lint
 
     - stage: test
       name: chrome
@@ -42,13 +41,13 @@ jobs:
     - stage: test
       name: electron-main
       script:
-        - xvfb-run npx aegir test -t electron-main -- --bail
+        - xvfb-run npx aegir test -t electron-main --bail
 
     - stage: test
       name: electron-renderer
       os: osx
       script:
-        - npx aegir test -t electron-renderer
+        - npx aegir test -t electron-renderer --bail
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
     - stage: test
       name: electron-renderer
       script:
-        - xvfb-run npx aegir test -t electron-renderer
+        - xvfb-run npx aegir test -t electron-renderer --timeout 80000
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
     - stage: test
       name: electron-renderer
       script:
-        - xvfb-run npx aegir test -t electron-renderer --timeout 80000
+        - xvfb-run npx aegir test -t electron-renderer -- --timeout 80000
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ jobs:
   include:
     - stage: check
       script:
-        - npx aegir build --bundlesize
-        - npx aegir dep-check
+        # - npx aegir build --bundlesize
+        # - npx aegir dep-check
         - npm run lint
 
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,9 @@ jobs:
 
     - stage: test
       name: electron-renderer
+      os: osx
       script:
-        - xvfb-run npx aegir test -t electron-renderer
+        - npx aegir test -t electron-renderer
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
-cache: npm
+# cache: npm
+cache: false
 stages:
   - check
   - test

--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
     "cross-env": "^5.2.1",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#fix/wantlist-renderer",
-    "ipfsd-ctl": "~0.46.1",
+    "interface-ipfs-core": "^0.113.1",
+    "ipfsd-ctl": "ipfs/js-ipfsd-ctl#fix/fix-electron",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cross-env": "^5.2.1",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.113.1",
+    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#fix/wantlist-renderer",
     "ipfsd-ctl": "~0.46.1",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "cross-env": "^5.2.1",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "github:ipfs/interface-ipfs-core#fix/fix-electron",
+    "interface-ipfs-core": "~0.114.0",
     "ipfsd-ctl": "^0.46.2",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "ky": "^0.13.0",
     "ky-universal": "^0.3.0",
     "lru-cache": "^5.1.1",
+    "merge-options": "^1.0.1",
     "multiaddr": "^7.1.0",
     "multibase": "~0.6.0",
     "multicodec": "~0.5.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cross-env": "^5.2.1",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#fix/electron-renderer",
+    "interface-ipfs-core": "^0.113.1",
     "ipfsd-ctl": "~0.46.1",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
     "interface-ipfs-core": "^0.113.1",
-    "ipfsd-ctl": "ipfs/js-ipfsd-ctl#fix/fix-electron",
+    "ipfsd-ctl": "github:ipfs/js-ipfsd-ctl#fix/fix-electron",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cross-env": "^5.2.1",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#fix/wantlist-renderer",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#fix/wantlist-renderer",
     "ipfsd-ctl": "~0.46.1",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "cross-env": "^5.2.1",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.113.0",
+    "interface-ipfs-core": "ipfs/interface-js-ipfs-core#fix/electron-renderer",
     "ipfsd-ctl": "~0.46.1",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "cids": "~0.7.1",
     "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
     "debug": "^4.1.0",
+    "delay": "^4.3.0",
     "detect-node": "^2.0.4",
     "end-of-stream": "^1.4.1",
     "err-code": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "through2": "^3.0.1"
   },
   "devDependencies": {
-    "aegir": "^20.1.0",
+    "aegir": "ipfs/aegir#chore/update-deps2",
     "browser-process-platform": "~0.1.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "through2": "^3.0.1"
   },
   "devDependencies": {
-    "aegir": "ipfs/aegir#chore/update-deps2",
+    "aegir": "ipfs/aegir#master",
     "browser-process-platform": "~0.1.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
@@ -109,7 +109,7 @@
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
     "interface-ipfs-core": "github:ipfs/interface-ipfs-core#fix/fix-electron",
-    "ipfsd-ctl": "github:ipfs/js-ipfsd-ctl#fix/fix-electron",
+    "ipfsd-ctl": "^0.46.2",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "through2": "^3.0.1"
   },
   "devDependencies": {
-    "aegir": "ipfs/aegir#master",
+    "aegir": "^20.2.0",
     "browser-process-platform": "~0.1.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "cross-env": "^5.2.1",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.113.1",
+    "interface-ipfs-core": "github:ipfs/interface-ipfs-core#fix/fix-electron",
     "ipfsd-ctl": "github:ipfs/js-ipfsd-ctl#fix/fix-electron",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -99,15 +99,15 @@
     "through2": "^3.0.1"
   },
   "devDependencies": {
-    "aegir": "^20.0.0",
+    "aegir": "^20.1.0",
     "browser-process-platform": "~0.1.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^5.2.1",
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.112.0",
-    "ipfsd-ctl": "~0.45.0",
+    "interface-ipfs-core": "^0.113.0",
+    "ipfsd-ctl": "~0.46.1",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"
   },

--- a/src/add/form-data.browser.js
+++ b/src/add/form-data.browser.js
@@ -1,7 +1,6 @@
 'use strict'
 /* eslint-env browser */
 
-const { Buffer } = require('buffer')
 const normaliseInput = require('ipfs-utils/src/files/normalise-input')
 
 exports.toFormData = async input => {
@@ -16,12 +15,12 @@ exports.toFormData = async input => {
       // One day, this will be browser streams
       const bufs = []
       for await (const chunk of file.content) {
-        bufs.push(Buffer.isBuffer(chunk) ? chunk.buffer : chunk)
+        bufs.push(chunk)
       }
 
-      formData.append(`file-${i}`, new Blob(bufs, { type: 'application/octet-stream' }), file.path)
+      formData.append(`file-${i}`, new Blob(bufs, { type: 'application/octet-stream' }), encodeURIComponent(file.path))
     } else {
-      formData.append(`dir-${i}`, new Blob([], { type: 'application/x-directory' }), file.path)
+      formData.append(`dir-${i}`, new Blob([], { type: 'application/x-directory' }), encodeURIComponent(file.path))
     }
 
     i++

--- a/src/add/form-data.js
+++ b/src/add/form-data.js
@@ -4,6 +4,7 @@ const FormData = require('form-data')
 const { Buffer } = require('buffer')
 const toStream = require('it-to-stream')
 const normaliseInput = require('ipfs-utils/src/files/normalise-input')
+const { isElectronRenderer } = require('ipfs-utils/src/env')
 
 exports.toFormData = async input => {
   const files = normaliseInput(input)
@@ -39,4 +40,10 @@ exports.toFormData = async input => {
   }
 
   return formData
+}
+
+// TODO remove this when upstream fix for ky-universal is merged
+// also this should only be necessary when nodeIntegration is false in electron renderer
+if (isElectronRenderer) {
+  exports.toFormData = require('./form-data.browser').toFormData
 }

--- a/src/add/form-data.js
+++ b/src/add/form-data.js
@@ -43,6 +43,7 @@ exports.toFormData = async input => {
 }
 
 // TODO remove this when upstream fix for ky-universal is merged
+// https://github.com/sindresorhus/ky-universal/issues/9
 // also this should only be necessary when nodeIntegration is false in electron renderer
 if (isElectronRenderer) {
   exports.toFormData = require('./form-data.browser').toFormData

--- a/src/dht/findpeer.js
+++ b/src/dht/findpeer.js
@@ -32,7 +32,7 @@ module.exports = (send) => {
       // 2 = FinalPeer
       // https://github.com/libp2p/go-libp2p-core/blob/6e566d10f4a5447317a66d64c7459954b969bdab/routing/query.go#L18
       if (!res || res.Type !== 2) {
-        const errMsg = `key was not found (type 4)`
+        const errMsg = 'key was not found (type 4)'
         return callback(errcode(new Error(errMsg), 'ERR_KEY_TYPE_4_NOT_FOUND'))
       }
 

--- a/src/id.js
+++ b/src/id.js
@@ -11,6 +11,7 @@ module.exports = (arg) => {
       callback = opts
       opts = undefined
     }
+
     send({
       path: 'id',
       args: opts
@@ -18,6 +19,7 @@ module.exports = (arg) => {
       if (err) {
         return callback(err)
       }
+      console.log('IDDDDDDDDDDDDDDD', result)
       const identity = {
         id: result.ID,
         publicKey: result.PublicKey,

--- a/src/id.js
+++ b/src/id.js
@@ -19,7 +19,6 @@ module.exports = (arg) => {
       if (err) {
         return callback(err)
       }
-      console.log('IDDDDDDDDDDDDDDD', result)
       const identity = {
         id: result.ID,
         publicKey: result.PublicKey,

--- a/src/id.js
+++ b/src/id.js
@@ -16,7 +16,6 @@ module.exports = (arg) => {
       path: 'id',
       args: opts
     }, (err, result) => {
-      console.log('TCL: result', result)
       if (err) {
         return callback(err)
       }

--- a/src/id.js
+++ b/src/id.js
@@ -16,6 +16,7 @@ module.exports = (arg) => {
       path: 'id',
       args: opts
     }, (err, result) => {
+      console.log('TCL: result', result)
       if (err) {
         return callback(err)
       }

--- a/test/get.spec.js
+++ b/test/get.spec.js
@@ -9,7 +9,6 @@ const chaiAsPromised = require('chai-as-promised')
 const expect = chai.expect
 chai.use(dirtyChai)
 chai.use(chaiAsPromised)
-const isNode = require('detect-node')
 const loadFixture = require('aegir/fixtures')
 
 const ipfsClient = require('../src')
@@ -75,26 +74,19 @@ describe('.get (specific go-ipfs features)', function () {
   })
 
   it('add path containing "+"s (for testing get)', async () => {
-    if (!isNode) {
-      return
-    }
-
     const filename = 'ti,c64x+mega++mod-pic.txt'
     const subdir = 'tmp/c++files'
     const expectedCid = 'QmPkmARcqjo5fqK1V1o8cFsuaXxWYsnwCNLJUYS4KeZyff'
+    const path = `${subdir}/${filename}`
     const files = await ipfs.add([{
-      path: subdir + '/' + filename,
-      content: Buffer.from(subdir + '/' + filename, 'utf-8')
+      path,
+      content: Buffer.from(path)
     }])
 
     expect(files[2].hash).to.equal(expectedCid)
   })
 
   it('get path containing "+"s', async () => {
-    if (!isNode) {
-      return
-    }
-
     const cid = 'QmPkmARcqjo5fqK1V1o8cFsuaXxWYsnwCNLJUYS4KeZyff'
     let count = 0
     const files = await ipfs.get(cid)

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -54,6 +54,8 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.dag(defaultCommonFactory, {
+    only: true,
+
     skip: [
       // dag.tree
       {
@@ -81,7 +83,6 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.dht(defaultCommonFactory, {
-    only: true,
     skip: [
       // dht.findpeer
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -54,7 +54,6 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.dag(defaultCommonFactory, {
-    only: true,
     skip: [
       // dag.tree
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -81,6 +81,7 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.dht(defaultCommonFactory, {
+    only: true,
     skip: [
       // dht.findpeer
       {
@@ -187,11 +188,7 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.miscellaneous(defaultCommonFactory, {
-    only: [
-      { name: 'should get the node ID (promised)' },
-      { name: 'should get the node version' },
-      { name: 'should resolve an IPFS hash' }
-    ],
+    only: true,
     skip: [
       // stop
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -187,11 +187,6 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.miscellaneous(defaultCommonFactory, {
-    only: [
-      {
-        name: 'should resolve an IPFS hash'
-      }
-    ],
     skip: [
       // stop
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -102,38 +102,28 @@ describe('interface-ipfs-core tests', () => {
 
   tests.filesRegular(defaultCommonFactory, {
     skip: [
-      // .add
-      isNode ? null : {
-        name: 'should add a nested directory as array of tupples',
-        reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      },
-      isNode ? null : {
-        name: 'should add a nested directory as array of tupples with progress',
-        reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      },
-      // .addPullStream
-      isNode ? null : {
-        name: 'should add pull stream of valid files and dirs',
-        reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      },
-      // .addReadableStream
-      isNode ? null : {
-        name: 'should add readable stream of valid files and dirs',
-        reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      },
+      // // .add
+      // isNode ? null : {
+      //   name: 'should add a nested directory as array of tupples',
+      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
+      // },
+      // isNode ? null : {
+      //   name: 'should add a nested directory as array of tupples with progress',
+      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
+      // },
+      // // .addPullStream
+      // isNode ? null : {
+      //   name: 'should add pull stream of valid files and dirs',
+      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
+      // },
+      // // .addReadableStream
+      // isNode ? null : {
+      //   name: 'should add readable stream of valid files and dirs',
+      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
+      // },
       // .addFromFs
       isNode ? null : {
         name: 'addFromFs',
-        reason: 'Not designed to run in the browser'
-      },
-      // .addFromURL
-      isNode ? null : {
-        name: 'addFromURL',
-        reason: 'Not designed to run in the browser'
-      },
-      // TODO: remove when interface-ipfs-core updated
-      isNode ? null : {
-        name: 'addFromUrl',
         reason: 'Not designed to run in the browser'
       },
       // .catPullStream
@@ -148,27 +138,27 @@ describe('interface-ipfs-core tests', () => {
       {
         name: 'should export a chunk of a file in a Readable Stream',
         reason: 'TODO not implemented in go-ipfs yet'
-      },
-      // .get
-      isNode ? null : {
-        name: 'should get a directory',
-        reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      },
-      // .ls
-      isNode ? null : {
-        name: 'should ls with a base58 encoded CID',
-        reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      },
-      // .lsPullStream
-      isNode ? null : {
-        name: 'should pull stream ls with a base58 encoded CID',
-        reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      },
-      // .lsReadableStream
-      isNode ? null : {
-        name: 'should readable stream ls with a base58 encoded CID',
-        reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
       }
+      // // .get
+      // isNode ? null : {
+      //   name: 'should get a directory',
+      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
+      // },
+      // // .ls
+      // isNode ? null : {
+      //   name: 'should ls with a base58 encoded CID',
+      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
+      // },
+      // // .lsPullStream
+      // isNode ? null : {
+      //   name: 'should pull stream ls with a base58 encoded CID',
+      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
+      // },
+      // // .lsReadableStream
+      // isNode ? null : {
+      //   name: 'should readable stream ls with a base58 encoded CID',
+      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
+      // }
     ]
   })
 

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -54,7 +54,6 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.dag(defaultCommonFactory, {
-    only: true,
     skip: [
       // dag.tree
       {
@@ -188,7 +187,11 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.miscellaneous(defaultCommonFactory, {
-    only: true,
+    only: [
+      {
+        name: 'should get the node version'
+      }
+    ],
     skip: [
       // stop
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -266,5 +266,5 @@ describe('interface-ipfs-core tests', () => {
 
   tests.stats(defaultCommonFactory)
 
-  tests.swarm(CommonFactory.create2())
+  tests.swarm(CommonFactory.createAsync())
 })

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -187,6 +187,11 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.miscellaneous(defaultCommonFactory, {
+    only: [
+      {
+        name: 'should resolve an IPFS hash'
+      }
+    ],
     skip: [
       // stop
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -80,25 +80,25 @@ describe.only('interface-ipfs-core tests', () => {
     ]
   })
 
-  // tests.dht(defaultCommonFactory, {
-  //   skip: [
-  //     // dht.findpeer
-  //     {
-  //       name: 'should fail to find other peer if peer does not exist',
-  //       reason: 'FIXME checking what is exactly go-ipfs returning https://github.com/ipfs/go-ipfs/issues/3862#issuecomment-294168090'
-  //     },
-  //     // dht.findprovs
-  //     {
-  //       name: 'should take options to override timeout config',
-  //       reason: 'FIXME go-ipfs does not support a timeout option'
-  //     },
-  //     // dht.get
-  //     {
-  //       name: 'should get a value after it was put on another node',
-  //       reason: 'FIXME go-ipfs errors with  Error: key was not found (type 6) https://github.com/ipfs/go-ipfs/issues/3862'
-  //     }
-  //   ]
-  // })
+  tests.dht(defaultCommonFactory, {
+    skip: [
+      // dht.findpeer
+      {
+        name: 'should fail to find other peer if peer does not exist',
+        reason: 'FIXME checking what is exactly go-ipfs returning https://github.com/ipfs/go-ipfs/issues/3862#issuecomment-294168090'
+      },
+      // dht.findprovs
+      {
+        name: 'should take options to override timeout config',
+        reason: 'FIXME go-ipfs does not support a timeout option'
+      },
+      // dht.get
+      {
+        name: 'should get a value after it was put on another node',
+        reason: 'FIXME go-ipfs errors with  Error: key was not found (type 6) https://github.com/ipfs/go-ipfs/issues/3862'
+      }
+    ]
+  })
 
   tests.filesRegular(defaultCommonFactory, {
     skip: [
@@ -267,31 +267,11 @@ describe.only('interface-ipfs-core tests', () => {
 
   tests.stats(defaultCommonFactory)
 
-  tests.swarm(CommonFactory.create({
-    createSetup ({ ipfsFactory, nodes }) {
-      return callback => {
-        callback(null, {
-          spawnNode (repoPath, config, cb) {
-            if (typeof repoPath === 'function') {
-              cb = repoPath
-              repoPath = undefined
-            }
-
-            if (typeof config === 'function') {
-              cb = config
-              config = undefined
-            }
-
-            const spawnOptions = { repoPath, config, initOptions: { bits: 1024, profile: 'test' } }
-
-            ipfsFactory.spawn(spawnOptions)
-              .then(ipfsd => {
-                nodes.push(ipfsd)
-                cb(null, ipfsClient(ipfsd.apiAddr))
-              }, cb)
-          }
-        })
+  tests.swarm(defaultCommonFactory, {
+    only: [
+      {
+        name: 'should connect to a peer (promised)'
       }
-    }
-  }))
+    ]
+  })
 })

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -101,25 +101,6 @@ describe('interface-ipfs-core tests', () => {
 
   tests.filesRegular(defaultCommonFactory, {
     skip: [
-      // // .add
-      // isNode ? null : {
-      //   name: 'should add a nested directory as array of tupples',
-      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      // },
-      // isNode ? null : {
-      //   name: 'should add a nested directory as array of tupples with progress',
-      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      // },
-      // // .addPullStream
-      // isNode ? null : {
-      //   name: 'should add pull stream of valid files and dirs',
-      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      // },
-      // // .addReadableStream
-      // isNode ? null : {
-      //   name: 'should add readable stream of valid files and dirs',
-      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      // },
       // .addFromFs
       isNode ? null : {
         name: 'addFromFs',
@@ -138,26 +119,6 @@ describe('interface-ipfs-core tests', () => {
         name: 'should export a chunk of a file in a Readable Stream',
         reason: 'TODO not implemented in go-ipfs yet'
       }
-      // // .get
-      // isNode ? null : {
-      //   name: 'should get a directory',
-      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      // },
-      // // .ls
-      // isNode ? null : {
-      //   name: 'should ls with a base58 encoded CID',
-      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      // },
-      // // .lsPullStream
-      // isNode ? null : {
-      //   name: 'should pull stream ls with a base58 encoded CID',
-      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      // },
-      // // .lsReadableStream
-      // isNode ? null : {
-      //   name: 'should readable stream ls with a base58 encoded CID',
-      //   reason: 'FIXME https://github.com/ipfs/js-ipfs-http-client/issues/339'
-      // }
     ]
   })
 

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -268,13 +268,6 @@ describe.only('interface-ipfs-core tests', () => {
   tests.stats(defaultCommonFactory)
 
   tests.swarm(CommonFactory.create2(), {
-    only: [
-      {
-        name: 'should connect to a peer (promised)'
-      },
-      {
-        name: 'should connect to a peer'
-      }
-    ]
+    only: true
   })
 })

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -54,6 +54,7 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.dag(defaultCommonFactory, {
+    only: true,
     skip: [
       // dag.tree
       {
@@ -187,11 +188,7 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.miscellaneous(defaultCommonFactory, {
-    only: [
-      {
-        name: 'should get the node version'
-      }
-    ],
+    only: true,
     skip: [
       // stop
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -7,7 +7,7 @@ const CommonFactory = require('./utils/interface-common-factory')
 const ipfsClient = require('../src')
 const isWindows = process.platform && process.platform === 'win32'
 
-describe('interface-ipfs-core tests', () => {
+describe.only('interface-ipfs-core tests', () => {
   const defaultCommonFactory = CommonFactory.create()
 
   tests.bitswap(defaultCommonFactory, {
@@ -54,8 +54,6 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.dag(defaultCommonFactory, {
-    only: true,
-
     skip: [
       // dag.tree
       {
@@ -82,25 +80,25 @@ describe('interface-ipfs-core tests', () => {
     ]
   })
 
-  tests.dht(defaultCommonFactory, {
-    skip: [
-      // dht.findpeer
-      {
-        name: 'should fail to find other peer if peer does not exist',
-        reason: 'FIXME checking what is exactly go-ipfs returning https://github.com/ipfs/go-ipfs/issues/3862#issuecomment-294168090'
-      },
-      // dht.findprovs
-      {
-        name: 'should take options to override timeout config',
-        reason: 'FIXME go-ipfs does not support a timeout option'
-      },
-      // dht.get
-      {
-        name: 'should get a value after it was put on another node',
-        reason: 'FIXME go-ipfs errors with  Error: key was not found (type 6) https://github.com/ipfs/go-ipfs/issues/3862'
-      }
-    ]
-  })
+  // tests.dht(defaultCommonFactory, {
+  //   skip: [
+  //     // dht.findpeer
+  //     {
+  //       name: 'should fail to find other peer if peer does not exist',
+  //       reason: 'FIXME checking what is exactly go-ipfs returning https://github.com/ipfs/go-ipfs/issues/3862#issuecomment-294168090'
+  //     },
+  //     // dht.findprovs
+  //     {
+  //       name: 'should take options to override timeout config',
+  //       reason: 'FIXME go-ipfs does not support a timeout option'
+  //     },
+  //     // dht.get
+  //     {
+  //       name: 'should get a value after it was put on another node',
+  //       reason: 'FIXME go-ipfs errors with  Error: key was not found (type 6) https://github.com/ipfs/go-ipfs/issues/3862'
+  //     }
+  //   ]
+  // })
 
   tests.filesRegular(defaultCommonFactory, {
     skip: [
@@ -189,7 +187,6 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.miscellaneous(defaultCommonFactory, {
-    only: true,
     skip: [
       // stop
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -54,6 +54,7 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.dag(defaultCommonFactory, {
+    only: true,
     skip: [
       // dag.tree
       {
@@ -187,11 +188,7 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.miscellaneous(defaultCommonFactory, {
-    only: [
-      {
-        name: 'should resolve an IPFS hash'
-      }
-    ],
+    only: true,
     skip: [
       // stop
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -4,10 +4,9 @@
 const tests = require('interface-ipfs-core')
 const isNode = require('detect-node')
 const CommonFactory = require('./utils/interface-common-factory')
-const ipfsClient = require('../src')
 const isWindows = process.platform && process.platform === 'win32'
 
-describe.only('interface-ipfs-core tests', () => {
+describe('interface-ipfs-core tests', () => {
   const defaultCommonFactory = CommonFactory.create()
 
   tests.bitswap(defaultCommonFactory, {
@@ -267,7 +266,5 @@ describe.only('interface-ipfs-core tests', () => {
 
   tests.stats(defaultCommonFactory)
 
-  tests.swarm(CommonFactory.create2(), {
-    only: true
-  })
+  tests.swarm(CommonFactory.create2())
 })

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -187,7 +187,11 @@ describe('interface-ipfs-core tests', () => {
   })
 
   tests.miscellaneous(defaultCommonFactory, {
-    only: true,
+    only: [
+      { name: 'should get the node ID (promised)' },
+      { name: 'should get the node version' },
+      { name: 'should resolve an IPFS hash' }
+    ],
     skip: [
       // stop
       {

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -267,10 +267,13 @@ describe.only('interface-ipfs-core tests', () => {
 
   tests.stats(defaultCommonFactory)
 
-  tests.swarm(defaultCommonFactory, {
+  tests.swarm(CommonFactory.create2(), {
     only: [
       {
         name: 'should connect to a peer (promised)'
+      },
+      {
+        name: 'should connect to a peer'
       }
     ]
   })

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -72,6 +72,7 @@ function create2 () {
       const id = await node.api.id()
       node.api.peerId = id
 
+      console.log('spawned', id.id)
       return node.api
     }
 

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -26,8 +26,14 @@ function createFactory (options) {
             ipfsFactory.spawn(options.spawnOptions)
               .then((ipfsd) => {
                 nodes.push(ipfsd)
-                cb(null, ipfsClient(ipfsd.apiAddr))
-              }, cb)
+                console.log('TCL: spawnNode -> ipfsd', ipfsd)
+
+                setImmediate(() => cb(null, ipfsClient(ipfsd.apiAddr)))
+              })
+              .catch(err => {
+                console.log('TCL: spawnNode -> err', err)
+                setImmediate(() => cb(err))
+              })
           }
         })
       }

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -8,7 +8,7 @@ const ipfsClient = require('../../src')
 function createFactory (options) {
   options = options || {}
 
-  options.factoryOptions = options.factoryOptions || {}
+  options.factoryOptions = options.factoryOptions || { IpfsClient: ipfsClient }
   options.spawnOptions = options.spawnOptions || { initOptions: { bits: 1024, profile: 'test' } }
 
   const ipfsFactory = IPFSFactory.create(options.factoryOptions)
@@ -23,14 +23,15 @@ function createFactory (options) {
       setup = (callback) => {
         callback(null, {
           spawnNode (cb) {
+            console.log('TCL: spawnNode -> spawn')
             ipfsFactory.spawn(options.spawnOptions)
               .then((ipfsd) => {
                 nodes.push(ipfsd)
-                console.log('TCL: spawnNode -> ipfsd', ipfsd._apiAddr)
+                console.log('TCL: spawnNode -> ipfsd', ipfsd._apiAddr.toString())
                 console.log('TCL: spawnNode -> ipfsd', ipfsd.initialized)
                 console.log('TCL: spawnNode -> ipfsd', ipfsd.started)
 
-                setImmediate(() => cb(null, ipfsClient(ipfsd.apiAddr)))
+                setImmediate(() => cb(null, ipfsd.api))
               })
               .catch(err => {
                 console.log('TCL: spawnNode -> err', err)

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -52,9 +52,7 @@ function createFactory (options) {
   }
 }
 
-exports.create = createFactory
-
-function create2 (createFactoryOptions, createSpawnOptions) {
+function createAsync (createFactoryOptions, createSpawnOptions) {
   return () => {
     const nodes = []
     const setup = async (factoryOptions = {}, spawnOptions) => {
@@ -85,5 +83,7 @@ function create2 (createFactoryOptions, createSpawnOptions) {
     }
   }
 }
-
-exports.create2 = create2
+module.exports = {
+  createAsync,
+  create: createFactory
+}

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -45,7 +45,12 @@ function createFactory (options) {
     if (options.createTeardown) {
       teardown = options.createTeardown({ ipfsFactory, nodes }, options)
     } else {
-      teardown = callback => each(nodes, (node, cb) => node.stop().then(cb, cb), callback)
+      teardown = callback => each(nodes, (node, cb) => {
+        node
+          .stop()
+          .then(() => setImmediate(() => cb()))
+          .catch(err => setImmediate(() => cb(err)))
+      }, callback)
     }
 
     return { setup, teardown }

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -26,7 +26,7 @@ function createFactory (options) {
             ipfsFactory.spawn(options.spawnOptions)
               .then((ipfsd) => {
                 nodes.push(ipfsd)
-                console.log('TCL: spawnNode -> ipfsd', ipfsd.apiAddr)
+                console.log('TCL: spawnNode -> ipfsd', ipfsd._apiAddr)
                 console.log('TCL: spawnNode -> ipfsd', ipfsd.initialized)
                 console.log('TCL: spawnNode -> ipfsd', ipfsd.started)
 

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -28,8 +28,6 @@ function createFactory (options) {
               .then((ipfsd) => {
                 nodes.push(ipfsd)
                 console.log('TCL: spawnNode -> ipfsd', ipfsd._apiAddr.toString())
-                console.log('TCL: spawnNode -> ipfsd', ipfsd.initialized)
-                console.log('TCL: spawnNode -> ipfsd', ipfsd.started)
 
                 setImmediate(() => cb(null, ipfsd.api))
               })

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -24,16 +24,12 @@ function createFactory (options) {
       setup = (callback) => {
         callback(null, {
           spawnNode (cb) {
-            console.log('TCL: spawnNode -> spawn')
             ipfsFactory.spawn(options.spawnOptions)
               .then((ipfsd) => {
                 nodes.push(ipfsd)
-                console.log('TCL: spawnNode -> ipfsd', ipfsd._apiAddr.toString())
-
                 setImmediate(() => cb(null, ipfsd.api))
               })
               .catch(err => {
-                console.log('TCL: spawnNode -> err', err)
                 setImmediate(() => cb(err))
               })
           }
@@ -77,7 +73,6 @@ function create2 (createFactoryOptions, createSpawnOptions) {
       const id = await node.api.id()
       node.api.peerId = id
 
-      console.log('spawned', id.id)
       return node.api
     }
 

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -26,7 +26,9 @@ function createFactory (options) {
             ipfsFactory.spawn(options.spawnOptions)
               .then((ipfsd) => {
                 nodes.push(ipfsd)
-                console.log('TCL: spawnNode -> ipfsd', ipfsd)
+                console.log('TCL: spawnNode -> ipfsd', ipfsd.apiAddr)
+                console.log('TCL: spawnNode -> ipfsd', ipfsd.initialized)
+                console.log('TCL: spawnNode -> ipfsd', ipfsd.started)
 
                 setImmediate(() => cb(null, ipfsClient(ipfsd.apiAddr)))
               })

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -58,14 +58,19 @@ function createFactory (options) {
 
 exports.create = createFactory
 
-function create2 () {
+function create2 (createFactoryOptions, createSpawnOptions) {
   return () => {
     const nodes = []
     const setup = async (factoryOptions = {}, spawnOptions) => {
-      const ipfsFactory = IPFSFactory.create(merge({ IpfsClient: ipfsClient }, factoryOptions))
+      const ipfsFactory = IPFSFactory.create(merge(
+        { IpfsClient: ipfsClient },
+        factoryOptions,
+        createFactoryOptions
+      ))
       const node = await ipfsFactory.spawn(merge(
         { initOptions: { profile: 'test' } },
-        spawnOptions
+        spawnOptions,
+        createSpawnOptions
       ))
       nodes.push(node)
 


### PR DESCRIPTION
- temp fix for electron renderer until ky-universal is fixed
- Blob can accept Buffer directly
  - Buffer.buffer triggered a super weird bug in electron renderer
- enable a bunch of tests in the browser
- xvfb-run makes electron go crazy
- detect-node needs to be removed everywhere and ipfs-utils/src/env.js should be used
- If you mix promises and callbacks inside, call the callback with setImmediate