### PR TITLE
fix: get correct remote node config

### DIFF
--- a/src/add-from-fs/index.js
+++ b/src/add-from-fs/index.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const configure = require('../lib/configure')
 const globSource = require('ipfs-utils/src/files/glob-source')
 
-module.exports = configure(({ ky }) => {
-  const add = require('../add')({ ky })
+module.exports = (config) => {
+  const add = require('../add')(config)
   return (path, options) => add(globSource(path, options), options)
-})
+}

--- a/src/add-from-url.js
+++ b/src/add-from-url.js
@@ -1,11 +1,10 @@
 'use strict'
 
 const kyDefault = require('ky-universal').default
-const configure = require('./lib/configure')
 const toIterable = require('./lib/stream-to-iterable')
 
-module.exports = configure(({ ky }) => {
-  const add = require('./add')({ ky })
+module.exports = (config) => {
+  const add = require('./add')(config)
 
   return (url, options) => (async function * () {
     options = options || {}
@@ -19,4 +18,4 @@ module.exports = configure(({ ky }) => {
 
     yield * add(input, options)
   })()
-})
+}

--- a/src/pubsub/subscribe.js
+++ b/src/pubsub/subscribe.js
@@ -9,9 +9,10 @@ const configure = require('../lib/configure')
 const toIterable = require('../lib/stream-to-iterable')
 const SubscriptionTracker = require('./subscription-tracker')
 
-module.exports = configure(({ ky }) => {
+module.exports = configure((config) => {
+  const ky = config.ky
   const subsTracker = SubscriptionTracker.singleton()
-  const publish = require('./publish')({ ky })
+  const publish = require('./publish')(config)
 
   return async (topic, handler, options) => {
     options = options || {}


### PR DESCRIPTION
I noticed some calls would fail during tests when the daemon was listening on non-standard ports, this was because when commands `require` other commands that use `ky`, we are passing the `ky` instance in as the sole property of an object that usually contains the host and port number of the remote node's API server.