### PR TITLE
fix: pull in preconfigured chai from interface tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "browser-process-platform": "~0.1.1",
     "cross-env": "^6.0.0",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.115.0",
+    "interface-ipfs-core": "^0.115.3",
     "ipfsd-ctl": "^0.47.1",
     "nock": "^11.3.2",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -104,10 +104,7 @@
   "devDependencies": {
     "aegir": "^20.3.1",
     "browser-process-platform": "~0.1.1",
-    "chai": "^4.2.0",
-    "chai-as-promised": "^7.1.1",
     "cross-env": "^6.0.0",
-    "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
     "interface-ipfs-core": "^0.115.0",
     "ipfsd-ctl": "^0.47.1",

--- a/test/commands.spec.js
+++ b/test/commands.spec.js
@@ -1,13 +1,8 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const ipfsClient = require('../src')
-
 const f = require('./utils/factory')
 
 describe('.commands', function () {

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -2,11 +2,7 @@
 'use strict'
 
 const multiaddr = require('multiaddr')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const f = require('./utils/factory')
 const ipfsClient = require('../src/index.js')
 

--- a/test/custom-headers.spec.js
+++ b/test/custom-headers.spec.js
@@ -2,11 +2,7 @@
 'use strict'
 
 const isNode = require('detect-node')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const ipfsClient = require('../src')
 const f = require('./utils/factory')
 

--- a/test/dag.spec.js
+++ b/test/dag.spec.js
@@ -3,12 +3,7 @@
 
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const chaiAsPromised = require('chai-as-promised')
-const expect = chai.expect
-chai.use(dirtyChai)
-chai.use(chaiAsPromised)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const { DAGNode } = require('ipld-dag-pb')
 const CID = require('cids')
 const ipfsClient = require('../src')

--- a/test/diag.spec.js
+++ b/test/diag.spec.js
@@ -1,12 +1,8 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const platform = require('browser-process-platform')
-
 const ipfsClient = require('../src')
 const f = require('./utils/factory')
 

--- a/test/endpoint-config.spec.js
+++ b/test/endpoint-config.spec.js
@@ -2,12 +2,8 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const isNode = require('detect-node')
-
 const ipfsClient = require('../src')
 const f = require('./utils/factory')
 

--- a/test/exports.spec.js
+++ b/test/exports.spec.js
@@ -9,10 +9,7 @@ const multicodec = require('multicodec')
 const multihash = require('multihashes')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 
 const IpfsHttpClient = require('../')
 

--- a/test/files-mfs.spec.js
+++ b/test/files-mfs.spec.js
@@ -2,12 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const chaiAsPromised = require('chai-as-promised')
-const expect = chai.expect
-chai.use(dirtyChai)
-chai.use(chaiAsPromised)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const loadFixture = require('aegir/fixtures')
 const mh = require('multihashes')
 const CID = require('cids')

--- a/test/get.spec.js
+++ b/test/get.spec.js
@@ -3,12 +3,7 @@
 
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const chaiAsPromised = require('chai-as-promised')
-const expect = chai.expect
-chai.use(dirtyChai)
-chai.use(chaiAsPromised)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const loadFixture = require('aegir/fixtures')
 
 const ipfsClient = require('../src')

--- a/test/key.spec.js
+++ b/test/key.spec.js
@@ -2,11 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const ipfsClient = require('../src')
 const f = require('./utils/factory')
 

--- a/test/lib.configure.spec.js
+++ b/test/lib.configure.spec.js
@@ -1,13 +1,9 @@
 /* eslint-env mocha, browser */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const Multiaddr = require('multiaddr')
 const { isBrowser, isWebWorker } = require('ipfs-utils/src/env')
-
 const configure = require('../src/lib/configure')
 
 describe('lib/configure', () => {

--- a/test/lib.error-handler.spec.js
+++ b/test/lib.error-handler.spec.js
@@ -1,11 +1,8 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const { HTTPError } = require('ky-universal')
-const expect = chai.expect
-chai.use(dirtyChai)
 const throwsAsync = require('./utils/throws-async')
 const errorHandler = require('../src/lib/error-handler')
 

--- a/test/lib.stream-to-iterable.spec.js
+++ b/test/lib.stream-to-iterable.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const toIterable = require('../src/lib/stream-to-iterable')
 
 describe('lib/stream-to-iterable', () => {

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -2,11 +2,7 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const ipfsClient = require('../src')
 const f = require('./utils/factory')
 

--- a/test/node/swarm.js
+++ b/test/node/swarm.js
@@ -1,14 +1,8 @@
 /* eslint-env mocha */
 'use strict'
 
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const nock = require('nock')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const chaiAsPromised = require('chai-as-promised')
-const expect = chai.expect
-chai.use(dirtyChai)
-chai.use(chaiAsPromised)
-
 const ipfsClient = require('../../src')
 
 describe('.swarm.peers', function () {

--- a/test/ping.spec.js
+++ b/test/ping.spec.js
@@ -1,12 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const chaiAsPromised = require('chai-as-promised')
-const expect = chai.expect
-chai.use(dirtyChai)
-chai.use(chaiAsPromised)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const pull = require('pull-stream/pull')
 const collect = require('pull-stream/sinks/collect')
 

--- a/test/repo.spec.js
+++ b/test/repo.spec.js
@@ -1,11 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const ipfsClient = require('../src')
 const f = require('./utils/factory')
 

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -1,10 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const isNode = require('detect-node')
 const ipfsClient = require('../src/index.js')
 const ndjson = require('ndjson')

--- a/test/stats.spec.js
+++ b/test/stats.spec.js
@@ -1,11 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const ipfsClient = require('../src')
 const f = require('./utils/factory')
 

--- a/test/sub-modules.spec.js
+++ b/test/sub-modules.spec.js
@@ -1,11 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('interface-ipfs-core/src/utils/mocha')
 const defaultConfig = require('../src/utils/default-config.js')
 const config = defaultConfig()
 config.host = 'test'


### PR DESCRIPTION
This is to work around https://github.com/chaijs/chai/issues/1298

Fundamentally we cannot pull in chai and add plugins to it without being careful of the order of those plugins as it's a singleton.

All we're really interested in is the `expect` function to just get the preconfigured one from the interface tests.