### PR TITLE
chore: avoid double travis build for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 cache: npm
 
+branches:
+  only:
+  - master
+  - /^release\/.*$/
+
 stages:
   - check
   - test


### PR DESCRIPTION
Disable building branches that aren't `master` or `release/*` - builds will happen for all PRs anyway, so this change means we don't get a branch build and a PR build on each PR.

The intention is to maintain `release/vN.x.x` branches similarly to `ipfs/js-ipfs` in case we need to backport fixes to older versions.