### PR TITLE
fix: use non-strict equivalence for options.preload

### DIFF
--- a/src/add/index.js
+++ b/src/add/index.js
@@ -28,7 +28,7 @@ module.exports = configure(({ ky }) => {
     if (options.silent) searchParams.set('silent', options.silent)
     if (options.trickle != null) searchParams.set('trickle', options.trickle)
     if (options.wrapWithDirectory != null) searchParams.set('wrap-with-directory', options.wrapWithDirectory)
-    if (options.preload !== null) searchParams.set('preload', options.preload)
+    if (options.preload != null) searchParams.set('preload', options.preload)
 
     const res = await ky.post('add', {
       timeout: options.timeout,


### PR DESCRIPTION
Only came up when testing `js-ipfs`, I think because preloading is not a thing in `go-ipfs` so we don't have much (any?) of it in the interface tests, and at any rate the interface tests of `js-ipfs-http-client` are run against `go-ipfs`.

Fixes broken build of https://github.com/ipfs/js-ipfs/pull/2555 and others.