### PR TITLE
chore: enable name tests

### DIFF
--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -204,6 +204,13 @@ describe('interface-ipfs-core tests', () => {
     ]
   })
 
+  tests.name(CommonFactory.create({
+    spawnOptions: {
+      args: ['--offline'],
+      initOptions: { bits: 1024 }
+    }
+  }))
+
   // TODO: uncomment after https://github.com/ipfs/interface-ipfs-core/pull/361 being merged and a new release
   tests.namePubsub(CommonFactory.create({
     spawnOptions: {


### PR DESCRIPTION
<del>This PR enables `interface-js-ipfs-core` tests of `ipfs.name`. That is all.</del>


Not needed, I used super old fork :/