### PR TITLE
feat: support name.resolve of peerid as cid

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "browser-process-platform": "~0.1.1",
     "cross-env": "^6.0.0",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.117.2",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#feat/peerid-as-cid",
     "ipfsd-ctl": "^0.47.1",
     "nock": "^11.4.0",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "browser-process-platform": "~0.1.1",
     "cross-env": "^6.0.0",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#feat/peerid-as-cid",
+    "interface-ipfs-core": "^0.118.0",
     "ipfsd-ctl": "^0.47.1",
     "nock": "^11.4.0",
     "stream-equal": "^1.1.1"

--- a/src/name/resolve.js
+++ b/src/name/resolve.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const promisify = require('promisify-es6')
+const CID = require('cids')
+const multihash = require('multihashes')
 
 const transform = function (res, callback) {
   callback(null, res.Path)
@@ -11,6 +13,19 @@ module.exports = (send) => {
     if (typeof (opts) === 'function') {
       callback = opts
       opts = {}
+    }
+
+    // normalize PeerIDs to Base58btc, so it works with go-ipfs <=0.4.22
+    if (typeof (args) === 'string') {
+      try {
+        const path = args.split('/')
+        if (path.length > 2) {
+          path[2] = multihash.toB58String(new CID(path[2]).multihash)
+          args = path.join('/')
+        }
+      } catch (err) {
+        // noop
+      }
     }
 
     send.andTransform({

--- a/src/name/resolve.js
+++ b/src/name/resolve.js
@@ -1,8 +1,6 @@
 'use strict'
 
 const promisify = require('promisify-es6')
-const CID = require('cids')
-const multihash = require('multihashes')
 
 const transform = function (res, callback) {
   callback(null, res.Path)
@@ -13,19 +11,6 @@ module.exports = (send) => {
     if (typeof (opts) === 'function') {
       callback = opts
       opts = {}
-    }
-
-    // normalize PeerIDs to Base58btc, so it works with go-ipfs <=0.4.22
-    if (typeof (args) === 'string') {
-      try {
-        const path = args.split('/')
-        if (path.length > 2) {
-          path[2] = multihash.toB58String(new CID(path[2]).multihash)
-          args = path.join('/')
-        }
-      } catch (err) {
-        // noop
-      }
     }
 
     send.andTransform({

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -176,7 +176,15 @@ describe('interface-ipfs-core tests', () => {
     spawnOptions: {
       args: ['--offline']
     }
-  }))
+  }), {
+    skip: [
+      // stop
+      {
+        name: 'should resolve a record from peerid as cidv1 in base32',
+        reason: 'TODO not implemented in go-ipfs yet: https://github.com/ipfs/go-ipfs/issues/5287'
+      }
+    ]
+  })
 
   // TODO: uncomment after https://github.com/ipfs/interface-ipfs-core/pull/361 being merged and a new release
   tests.namePubsub(CommonFactory.create({


### PR DESCRIPTION
This PR updates to `interface-ipfs-core": "^0.118.0` which includes test for resolving paths with libp2p-key represented as CIDv1 Base32.

### Open Problem

The problem is that go-ipfs 0.4.22 does not support PeerID as CID, so test added in https://github.com/ipfs/interface-js-ipfs-core/pull/553 fails:

```
  1) interface-ipfs-core tests
       .name.resolve offline
         should resolve a record from peerid as cidv1 in base32:
     Error: not a valid proquint string
```

<del>@alanshaw  not sure how to handle this. Wait for go-ipfs v0.5.0? Fixup on the fly in the meantime?</del>

<del>A hacky way to support CIDs when API is go-ipfs 0.4.22 or older is to convert toBase58btc before sending. See below.</del>

For now we skip cidv1b32 test, added todo to unskip when go-ipfs ships with native support.

closes https://github.com/ipfs/js-ipfs-http-client/pull/1147