### PR TITLE
fix: repo stat for non-numeric string values

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "browser-process-platform": "~0.1.1",
     "cross-env": "^6.0.0",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.119.0",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#test/add-human-option-test-repo-stat",
     "ipfsd-ctl": "^0.47.1",
     "nock": "^11.4.0",
     "stream-equal": "^1.1.1"

--- a/src/repo/stat.js
+++ b/src/repo/stat.js
@@ -3,13 +3,13 @@
 const promisify = require('promisify-es6')
 const Big = require('bignumber.js')
 
-const transform = function (res, callback) {
+const transform = ({ human }) => (res, callback) => {
   callback(null, {
-    numObjects: new Big(res.NumObjects),
-    repoSize: new Big(res.RepoSize),
+    numObjects: human ? res.NumObjects : new Big(res.NumObjects),
+    repoSize: human ? res.RepoSize : new Big(res.RepoSize),
     repoPath: res.RepoPath,
     version: res.Version,
-    storageMax: new Big(res.StorageMax)
+    storageMax: human ? res.StorageMax : new Big(res.StorageMax)
   })
 }
 
@@ -23,6 +23,6 @@ module.exports = (send) => {
     send.andTransform({
       path: 'repo/stat',
       qs: opts
-    }, transform, callback)
+    }, transform(opts), callback)
   })
 }

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -247,7 +247,14 @@ describe('interface-ipfs-core tests', () => {
     ] : null
   })
 
-  tests.repo(defaultCommonFactory)
+  tests.repo(defaultCommonFactory, {
+    skip: [
+      {
+        name: 'should get human readable repo stats',
+        reason: 'FIXME go-ipfs only has human option implemented for the cli'
+      }
+    ]
+  })
 
   tests.stats(defaultCommonFactory)
 


### PR DESCRIPTION
`new Big()` cannot be applied to non-numeric `string` variables, which can be the case when `human` option is `true`.
E.g.: `10GB`

This PR fixes that problem.

⚠️ It needs the following PR merged and released before this one can be:
- [ ] https://github.com/ipfs/interface-js-ipfs-core/pull/554