### PR TITLE
refactor: convert config API to async await

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,8 +1,10 @@
 'use strict'
 
+const callbackify = require('callbackify')
+
 module.exports = (send, config) => {
   return {
-    get: require('./get')(send),
+    get: callbackify.variadic(require('./get')(config)),
     set: require('./set')(send),
     replace: require('./replace')(send),
     profiles: {

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,14 +2,9 @@
 
 const callbackify = require('callbackify')
 
-module.exports = (send, config) => {
-  return {
-    get: callbackify.variadic(require('./get')(config)),
-    set: require('./set')(send),
-    replace: require('./replace')(send),
-    profiles: {
-      apply: require('./profiles/apply')(config),
-      list: require('./profiles/list')(config)
-    }
-  }
-}
+module.exports = config => ({
+  get: callbackify.variadic(require('./get')(config)),
+  set: callbackify.variadic(require('./set')(config)),
+  replace: callbackify.variadic(require('./replace')(config)),
+  profiles: require('./profiles')(config)
+})

--- a/src/config/profiles/apply.js
+++ b/src/config/profiles/apply.js
@@ -1,27 +1,24 @@
 'use strict'
 
-const callbackify = require('callbackify')
 const configure = require('../../lib/configure')
 
 module.exports = configure(({ ky }) => {
-  return callbackify.variadic(async (profile, options) => {
+  return async (profile, options) => {
     options = options || {}
+
+    const searchParams = new URLSearchParams(options.searchParams)
+    searchParams.set('arg', profile)
+    if (options.dryRun != null) searchParams.set('dry-run', options.dryRun)
 
     const res = await ky.post('config/profile/apply', {
       timeout: options.timeout,
       signal: options.signal,
       headers: options.headers,
-      searchParams: {
-        arg: profile,
-        // can only pass strings or numbers as values https://github.com/sindresorhus/ky/issues/182
-        'dry-run': options.dryRun ? 'true' : 'false'
-      }
-    })
-
-    const parsed = await res.json()
+      searchParams
+    }).json()
 
     return {
-      original: parsed.OldCfg, updated: parsed.NewCfg
+      original: res.OldCfg, updated: res.NewCfg
     }
-  })
+  }
 })

--- a/src/config/profiles/index.js
+++ b/src/config/profiles/index.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const callbackify = require('callbackify')
+
+module.exports = config => ({
+  apply: callbackify.variadic(require('./apply')(config)),
+  list: callbackify.variadic(require('./list')(config))
+})

--- a/src/config/profiles/list.js
+++ b/src/config/profiles/list.js
@@ -1,22 +1,19 @@
 'use strict'
 
-const callbackify = require('callbackify')
 const configure = require('../../lib/configure')
 const toCamel = require('../../lib/object-to-camel')
 
 module.exports = configure(({ ky }) => {
-  return callbackify.variadic(async (options) => {
+  return async (options) => {
     options = options || {}
 
     const res = await ky.get('config/profile/list', {
       timeout: options.timeout,
       signal: options.signal,
-      headers: options.headers
-    })
+      headers: options.headers,
+      searchParams: options.searchParams
+    }).json()
 
-    const parsed = await res.json()
-
-    return parsed
-      .map(profile => toCamel(profile))
-  })
+    return res.map(profile => toCamel(profile))
+  }
 })

--- a/src/config/set.js
+++ b/src/config/set.js
@@ -8,7 +8,7 @@ module.exports = configure(({ ky }) => {
     options = options || {}
 
     if (typeof key !== 'string') {
-      throw new Error('invalid key')
+      throw new Error('Invalid key type')
     }
 
     const searchParams = new URLSearchParams(options.searchParams)

--- a/src/config/set.js
+++ b/src/config/set.js
@@ -1,35 +1,36 @@
 'use strict'
 
-const promisify = require('promisify-es6')
+const configure = require('../lib/configure')
+const toCamel = require('../lib/object-to-camel')
 
-module.exports = (send) => {
-  return promisify((key, value, opts, callback) => {
-    if (typeof opts === 'function') {
-      callback = opts
-      opts = {}
-    }
+module.exports = configure(({ ky }) => {
+  return async (key, value, options) => {
+    options = options || {}
+
     if (typeof key !== 'string') {
-      return callback(new Error('Invalid key type'))
+      throw new Error('invalid key')
     }
 
-    if (value === undefined || Buffer.isBuffer(value)) {
-      return callback(new Error('Invalid value type'))
-    }
+    const searchParams = new URLSearchParams(options.searchParams)
 
     if (typeof value === 'boolean') {
+      searchParams.set('bool', true)
       value = value.toString()
-      opts = { bool: true }
     } else if (typeof value !== 'string') {
+      searchParams.set('json', true)
       value = JSON.stringify(value)
-      opts = { json: true }
     }
 
-    send({
-      path: 'config',
-      args: [key, value],
-      qs: opts,
-      files: undefined,
-      buffer: true
-    }, callback)
-  })
-}
+    searchParams.set('arg', key)
+    searchParams.append('arg', value)
+
+    const res = await ky.post('config', {
+      timeout: options.timeout,
+      signal: options.signal,
+      headers: options.headers,
+      searchParams
+    }).json()
+
+    return toCamel(res)
+  }
+})

--- a/src/lib/error-handler.js
+++ b/src/lib/error-handler.js
@@ -35,9 +35,15 @@ module.exports = async function errorHandler (input, options, response) {
   } catch (err) {
     log('Failed to parse error response', err)
     // Failed to extract/parse error message from response
-    throw new HTTPError(response)
+    msg = err.message
   }
 
-  if (!msg) throw new HTTPError(response)
-  throw Object.assign(new Error(msg), { status: response.status })
+  const error = new HTTPError(response)
+
+  // If we managed to extract a message from the response, use it
+  if (msg) {
+    error.message = msg
+  }
+
+  throw error
 }

--- a/src/utils/load-commands.js
+++ b/src/utils/load-commands.js
@@ -91,6 +91,7 @@ function requireCommands (send, config) {
     getEndpointConfig: require('../get-endpoint-config')(config),
     bitswap: require('../bitswap')(config),
     block: require('../block')(config),
+    config: require('../config')(config),
     dag: require('../dag')(config)
   }
 
@@ -122,7 +123,6 @@ function requireCommands (send, config) {
 
     // Miscellaneous
     commands: require('../commands'),
-    config: require('../config'),
     diag: require('../diag'),
     id: require('../id'),
     key: require('../key'),

--- a/test/lib.error-handler.spec.js
+++ b/test/lib.error-handler.spec.js
@@ -21,8 +21,9 @@ describe('lib/error-handler', () => {
 
     const err = await throwsAsync(errorHandler(null, null, res))
 
+    expect(err instanceof HTTPError).to.be.true()
     expect(err.message).to.eql('boom')
-    expect(err.status).to.eql(500)
+    expect(err.response.status).to.eql(500)
   })
 
   it('should gracefully fail on parse json', async () => {

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -112,7 +112,7 @@ describe('error handling', () => {
     })
   })
 
-  it('should handle JSON error response with invalid JSON', function (done) {
+  it.only('should handle JSON error response with invalid JSON', function (done) {
     if (!isNode) return this.skip()
 
     const server = require('http').createServer((req, res) => {
@@ -130,8 +130,10 @@ describe('error handling', () => {
       console.log('requesting...')
       ipfsClient('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
         console.log(err)
+        console.log('err.message=', err.message)
         expect(err).to.exist()
         expect(err.message).to.match(/invalid json/i)
+        console.log('closing...')
         server.close(done)
       })
     })

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -112,7 +112,7 @@ describe('error handling', () => {
     })
   })
 
-  it.only('should handle JSON error response with invalid JSON', function (done) {
+  it('should handle JSON error response with invalid JSON', function (done) {
     if (!isNode) return this.skip()
 
     const server = require('http').createServer((req, res) => {
@@ -127,13 +127,9 @@ describe('error handling', () => {
     })
 
     server.listen(6001, () => {
-      console.log('requesting...')
       ipfsClient('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
-        console.log(err)
-        console.log('err.message=', err.message)
         expect(err).to.exist()
-        expect(err.message).to.match(/invalid json/i)
-        console.log('closing...')
+        expect(err.message).to.include('Unexpected token M in JSON at position 2')
         server.close(done)
       })
     })

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -81,7 +81,7 @@ describe('error handling', () => {
     server.listen(6001, () => {
       ipfsClient('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
         expect(err).to.exist()
-        expect(err.statusCode).to.equal(403)
+        expect(err.response.status).to.equal(403)
         expect(err.message).to.equal('ipfs method not allowed')
         server.close(done)
       })
@@ -105,9 +105,8 @@ describe('error handling', () => {
     server.listen(6001, () => {
       ipfsClient('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
         expect(err).to.exist()
-        expect(err.statusCode).to.equal(400)
+        expect(err.response.status).to.equal(400)
         expect(err.message).to.equal('client error')
-        expect(err.code).to.equal(1)
         server.close(done)
       })
     })
@@ -130,7 +129,7 @@ describe('error handling', () => {
     server.listen(6001, () => {
       ipfsClient('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
         expect(err).to.exist()
-        expect(err.message).to.include('Invalid JSON')
+        expect(err.message).to.include('invalid json')
         server.close(done)
       })
     })

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -127,7 +127,9 @@ describe('error handling', () => {
     })
 
     server.listen(6001, () => {
+      console.log('requesting...')
       ipfsClient('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
+        console.log(err)
         expect(err).to.exist()
         expect(err.message).to.match(/invalid json/i)
         server.close(done)

--- a/test/request-api.spec.js
+++ b/test/request-api.spec.js
@@ -129,7 +129,7 @@ describe('error handling', () => {
     server.listen(6001, () => {
       ipfsClient('/ip4/127.0.0.1/tcp/6001').config.replace('test/fixtures/r-config.json', (err) => {
         expect(err).to.exist()
-        expect(err.message).to.include('invalid json')
+        expect(err.message).to.match(/invalid json/i)
         server.close(done)
       })
     })


### PR DESCRIPTION
BREAKING CHANGE: Errors returned from request failures are now all [`HTTPError`](https://github.com/sindresorhus/ky/blob/c0d9d2bb07e4c122a08f019b39e9c55a4c9324f3/index.js#L117-L123)s which carry a `response` property. This is a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) that can be used to inspect _all_ information relating to the HTTP response. This means that the `err.status` or `err.statusCode` property should now be accessed via `err.response.status`.