### PR TITLE
WIP feat: human option bitswap stat

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "browser-process-platform": "~0.1.1",
     "cross-env": "^6.0.0",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.119.0",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#test/add-human-option-test-bitswap-stat",
     "ipfsd-ctl": "^0.47.1",
     "nock": "^11.4.0",
     "stream-equal": "^1.1.1"

--- a/src/bitswap/stat.js
+++ b/src/bitswap/stat.js
@@ -7,27 +7,44 @@ module.exports = configure(({ ky }) => {
   return async (options) => {
     options = options || {}
 
+    const searchParams = new URLSearchParams(options.searchParams)
+    if (options.human) searchParams.set('human', options.human)
+
     const res = await ky.get('bitswap/stat', {
       timeout: options.timeout,
       signal: options.signal,
       headers: options.headers,
-      searchParams: options.searchParams
+      searchParams
     }).json()
 
-    return toCoreInterface(res)
+    return toCoreInterface(res, options)
   }
 })
 
-function toCoreInterface (res) {
+function toCoreInterface (res, { human }) {
   return {
-    provideBufLen: res.ProvideBufLen,
+    provideBufLen: human
+      ? res.ProvideBufLen
+      : new Big(res.ProvideBufLen),
     wantlist: res.Wantlist || [],
     peers: res.Peers || [],
-    blocksReceived: new Big(res.BlocksReceived),
-    dataReceived: new Big(res.DataReceived),
-    blocksSent: new Big(res.BlocksSent),
-    dataSent: new Big(res.DataSent),
-    dupBlksReceived: new Big(res.DupBlksReceived),
-    dupDataReceived: new Big(res.DupDataReceived)
+    blocksReceived: human
+      ? res.BlocksReceived
+      : new Big(res.BlocksReceived),
+    dataReceived: human
+      ? res.DataReceived
+      : new Big(res.DataReceived),
+    blocksSent: human
+      ? res.BlocksSent
+      : new Big(res.BlocksSent),
+    dataSent: human
+      ? res.DataSent
+      : new Big(res.DataSent),
+    dupBlksReceived: human
+      ? res.DupBlksReceived
+      : new Big(res.DupBlksReceived),
+    dupDataReceived: human
+      ? res.DupDataReceived
+      : new Big(res.DupDataReceived)
   }
 }

--- a/src/stats/bitswap.js
+++ b/src/stats/bitswap.js
@@ -3,17 +3,31 @@
 const promisify = require('promisify-es6')
 const Big = require('bignumber.js')
 
-const transform = function (res, callback) {
+const transform = ({ human }) => (res, callback) => {
   callback(null, {
-    provideBufLen: res.ProvideBufLen,
+    provideBufLen: human
+      ? res.ProvideBufLen
+      : new Big(res.ProvideBufLen),
     wantlist: res.Wantlist || [],
     peers: res.Peers || [],
-    blocksReceived: new Big(res.BlocksReceived),
-    dataReceived: new Big(res.DataReceived),
-    blocksSent: new Big(res.BlocksSent),
-    dataSent: new Big(res.DataSent),
-    dupBlksReceived: new Big(res.DupBlksReceived),
-    dupDataReceived: new Big(res.DupDataReceived)
+    blocksReceived: human
+      ? res.BlocksReceived
+      : new Big(res.BlocksReceived),
+    dataReceived: human
+      ? res.DataReceived
+      : new Big(res.DataReceived),
+    blocksSent: human
+      ? res.BlocksSent
+      : new Big(res.BlocksSent),
+    dataSent: human
+      ? res.DataSent
+      : new Big(res.DataSent),
+    dupBlksReceived: human
+      ? res.DupBlksReceived
+      : new Big(res.DupBlksReceived),
+    dupDataReceived: human
+      ? res.DupDataReceived
+      : new Big(res.DupDataReceived)
   })
 }
 
@@ -27,6 +41,6 @@ module.exports = (send) => {
     send.andTransform({
       path: 'stats/bitswap',
       qs: opts
-    }, transform, callback)
+    }, transform(opts), callback)
   })
 }

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -253,7 +253,14 @@ describe('interface-ipfs-core tests', () => {
 
   tests.repo(defaultCommonFactory)
 
-  tests.stats(defaultCommonFactory)
+  tests.stats(defaultCommonFactory, {
+    skip: [
+      {
+        name: 'should get human readable bitswap stats',
+        reason: 'FIXME go-ipfs only supports human option for the cli'
+      }
+    ]
+  })
 
   tests.swarm(CommonFactory.createAsync())
 })

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -16,6 +16,10 @@ describe('interface-ipfs-core tests', () => {
         name: 'should not get bitswap stats when offline',
         reason: 'FIXME go-ipfs returns an error https://github.com/ipfs/go-ipfs/issues/4078'
       },
+      {
+        name: 'should get human readable bitswap stats',
+        reason: 'FIXME go-ipfs only supports human option for the cli'
+      },
       // bitswap.wantlist
       {
         name: 'should not get the wantlist when offline',


### PR DESCRIPTION
This PR adds `human` argument to `api/v0/bitswap/stat` that will be able to print sizes in human readable format (e.g., 1K 234M 2G)

E.g.: 
```sh
curl "http://localhost:5001/api/v0/bitswap/stat?human=true"
```

⚠️It needs the following PR merged and released before this one can be:
- [ ] https://github.com/ipfs/interface-js-ipfs-core/pull/559