### PR TITLE
chore: change interface tests to async node creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "cross-env": "^6.0.0",
     "detect-node": "^2.0.4",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.121.0",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#chore/async-await-refactor",
     "ipfsd-ctl": "^0.47.1",
     "ndjson": "^1.5.0",
     "nock": "^11.4.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "cross-env": "^6.0.0",
     "detect-node": "^2.0.4",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#chore/async-await-refactor",
+    "interface-ipfs-core": "^0.122.0",
     "ipfsd-ctl": "^0.47.1",
     "ndjson": "^1.5.0",
     "nock": "^11.4.0",

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -7,7 +7,7 @@ const CommonFactory = require('./utils/interface-common-factory')
 const isWindows = process.platform && process.platform === 'win32'
 
 describe('interface-ipfs-core tests', () => {
-  const defaultCommonFactory = CommonFactory.create()
+  const defaultCommonFactory = CommonFactory.createAsync()
 
   tests.bitswap(defaultCommonFactory, {
     skip: [
@@ -172,7 +172,7 @@ describe('interface-ipfs-core tests', () => {
     ]
   })
 
-  tests.name(CommonFactory.create({
+  tests.name(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--offline']
     }
@@ -186,8 +186,7 @@ describe('interface-ipfs-core tests', () => {
     ]
   })
 
-  // TODO: uncomment after https://github.com/ipfs/interface-ipfs-core/pull/361 being merged and a new release
-  tests.namePubsub(CommonFactory.create({
+  tests.namePubsub(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--enable-namesys-pubsub'],
       initOptions: { bits: 1024, profile: 'test' }
@@ -228,7 +227,7 @@ describe('interface-ipfs-core tests', () => {
     ]
   })
 
-  tests.pubsub(CommonFactory.create({
+  tests.pubsub(CommonFactory.createAsync({
     spawnOptions: {
       args: ['--enable-pubsub-experiment'],
       initOptions: { bits: 1024, profile: 'test' }
@@ -251,5 +250,5 @@ describe('interface-ipfs-core tests', () => {
 
   tests.stats(defaultCommonFactory)
 
-  tests.swarm(CommonFactory.createAsync())
+  tests.swarm(defaultCommonFactory)
 })

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -6,10 +6,14 @@ const IPFSFactory = require('ipfsd-ctl')
 const ipfsClient = require('../../src')
 const merge = require('merge-options')
 
+const DEFAULT_FACTORY_OPTIONS = {
+  IpfsClient: ipfsClient
+}
+
 function createFactory (options) {
   options = options || {}
 
-  options.factoryOptions = options.factoryOptions || { IpfsClient: ipfsClient }
+  options.factoryOptions = options.factoryOptions || DEFAULT_FACTORY_OPTIONS
   options.spawnOptions = options.spawnOptions || { initOptions: { bits: 1024, profile: 'test' } }
 
   const ipfsFactory = IPFSFactory.create(options.factoryOptions)
@@ -52,19 +56,17 @@ function createFactory (options) {
   }
 }
 
-function createAsync (createFactoryOptions, createSpawnOptions) {
+function createAsync (options = {}) {
   return () => {
     const nodes = []
-    const setup = async (factoryOptions = {}, spawnOptions) => {
+    const setup = async (setupOptions = {}) => {
       const ipfsFactory = IPFSFactory.create(merge(
-        { IpfsClient: ipfsClient },
-        factoryOptions,
-        createFactoryOptions
+        setupOptions.factoryOptions,
+        options.factoryOptions || DEFAULT_FACTORY_OPTIONS
       ))
       const node = await ipfsFactory.spawn(merge(
-        { initOptions: { profile: 'test' } },
-        spawnOptions,
-        createSpawnOptions
+        setupOptions.spawnOptions,
+        options.spawnOptions || { initOptions: { profile: 'test' } }
       ))
       nodes.push(node)
 

--- a/test/utils/interface-common-factory.js
+++ b/test/utils/interface-common-factory.js
@@ -13,7 +13,7 @@ const DEFAULT_FACTORY_OPTIONS = {
 function createFactory (options) {
   options = options || {}
 
-  options.factoryOptions = options.factoryOptions || DEFAULT_FACTORY_OPTIONS
+  options.factoryOptions = options.factoryOptions || { ...DEFAULT_FACTORY_OPTIONS }
   options.spawnOptions = options.spawnOptions || { initOptions: { bits: 1024, profile: 'test' } }
 
   const ipfsFactory = IPFSFactory.create(options.factoryOptions)
@@ -61,8 +61,9 @@ function createAsync (options = {}) {
     const nodes = []
     const setup = async (setupOptions = {}) => {
       const ipfsFactory = IPFSFactory.create(merge(
+        options.factoryOptions ? {} : { ...DEFAULT_FACTORY_OPTIONS },
         setupOptions.factoryOptions,
-        options.factoryOptions || DEFAULT_FACTORY_OPTIONS
+        options.factoryOptions
       ))
       const node = await ipfsFactory.spawn(merge(
         setupOptions.spawnOptions,


### PR DESCRIPTION
This PR allows interface-core tests to create and spawn nodes asynchronously.

Related to:
https://github.com/ipfs/interface-js-ipfs-core/pull/562