### PR TITLE
fix: pin ls with multiple CIDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "cross-env": "^6.0.0",
     "detect-node": "^2.0.4",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.122.0",
+    "interface-ipfs-core": "^0.123.0",
     "ipfsd-ctl": "^0.47.1",
     "ndjson": "^1.5.0",
     "nock": "^11.4.0",

--- a/src/pin/ls.js
+++ b/src/pin/ls.js
@@ -9,10 +9,12 @@ module.exports = configure(({ ky }) => {
       path = null
     }
 
+    path = path || []
+    path = Array.isArray(path) ? path : [path]
     options = options || {}
 
     const searchParams = new URLSearchParams(options.searchParams)
-    if (path) searchParams.set('arg', `${path}`)
+    path.forEach(p => searchParams.append('arg', `${p}`))
     if (options.type) searchParams.set('type', options.type)
 
     const { Keys } = await ky.post('pin/ls', {


### PR DESCRIPTION
Fixes `pin.ls` with multiple CIDs, which was inadvertently unsupported since it wasn't documented but was being tested for in js-ipfs CLI tests.

https://github.com/ipfs/interface-js-ipfs-core/pull/563 adds a test and documents the feature.