### PR TITLE
Update package.json's main prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "src",
     "dist"
   ],
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "browser": {
     "glob": false,
     "fs": false,


### PR DESCRIPTION
It looks like this package does not work on Node < 10 because of the [for...await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) feature:

```
 /home/lion/Code/aragon/aragon-cli/packages/aragon-cli/node_modules/ipfs-http-client/src/files-regular/index.js:60
      for await (const entry of get(path, options)) {
          ^^^^^
 SyntaxError: Unexpected reserved word
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:616:28)
    at Module._compile (/home/lion/Code/aragon/aragon-cli/packages/aragon-cli/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (module.js:663:10)
    at extensions.(anonymous function) (/home/lion/Code/aragon/aragon-cli/packages/aragon-cli/node_modules/require-precompiled/index.js:16:3)
    at newLoader (/home/lion/Code/aragon/aragon-cli/packages/aragon-cli/node_modules/pirates/lib/index.js:104:7)
    at Object.require.extensions.(anonymous function) [as .js] (/home/lion/Code/aragon/aragon-cli/packages/aragon-cli/node_modules/ava/lib/worker/dependency-tracker.js:42:4)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
```

I think the issue here is that `main` points to `src` instead of `dist`.