### PR TITLE
refactor: use echo-server start and stop functions as promises

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const promisify = require('promisify-es6')
 const createServer = require('ipfsd-ctl').createServer
 const EchoServer = require('interface-ipfs-core/src/utils/echo-http-server')
 const server = createServer()
 const echoServer = EchoServer.createServer()
 
-const echoServerStart = promisify(echoServer.start)
-const echoServerStop = promisify(echoServer.stop)
 module.exports = {
   bundlesize: { maxSize: '246kB' },
   webpack: {
@@ -27,20 +24,20 @@ module.exports = {
   },
   hooks: {
     node: {
-      pre: () => echoServerStart(),
-      post: () => echoServerStop()
+      pre: () => echoServer.start(),
+      post: () => echoServer.stop()
     },
     browser: {
       pre: () => {
         return Promise.all([
           server.start(),
-          echoServerStart()
+          echoServer.start()
         ])
       },
       post: () => {
         return Promise.all([
           server.stop(),
-          echoServerStop()
+          echoServer.stop()
         ])
       }
     }

--- a/package.json
+++ b/package.json
@@ -84,11 +84,10 @@
     "cross-env": "^6.0.0",
     "detect-node": "^2.0.4",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "^0.123.0",
+    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#refactor/http-server-util",
     "ipfsd-ctl": "^0.47.1",
     "ndjson": "^1.5.0",
     "nock": "^11.4.0",
-    "promisify-es6": "^1.0.3",
     "pull-stream": "^3.6.14",
     "pump": "^3.0.0",
     "stream-equal": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "cross-env": "^6.0.0",
     "detect-node": "^2.0.4",
     "go-ipfs-dep": "^0.4.22",
-    "interface-ipfs-core": "github:ipfs/interface-js-ipfs-core#refactor/http-server-util",
+    "interface-ipfs-core": "^0.124.0",
     "ipfsd-ctl": "^0.47.1",
     "ndjson": "^1.5.0",
     "nock": "^11.4.0",


### PR DESCRIPTION
This PR refactors `.aegir.js` `pre` and `post` hooks. With https://github.com/ipfs/interface-js-ipfs-core/pull/565 refactor, there is no need to promisify both echo-server `start()` and `stop()`.

It also removes [`promisify-es6`](https://github.com/manuel-di-iorio/promisify-es6) dependency because it is not needed anymore. 

Depends on:
- https://github.com/ipfs/interface-js-ipfs-core/pull/565