### PR TITLE
WIP feat: add localResolve option to dag.get

### DIFF
--- a/src/dag/get.js
+++ b/src/dag/get.js
@@ -25,6 +25,16 @@ module.exports = config => {
       options = options || {}
 
       const resolved = await dagResolve(cid, path, options)
+
+      // TODO: delete this comment
+      // Return like this to be consistent with what core dag/get is returning
+      if (options.localResolve) {
+        return {
+          value: resolved.cid,
+          remainderPath: resolved.remPath
+        }
+      }
+
       const block = await getBlock(resolved.cid, options)
       const dagResolver = resolvers[block.cid.codec]
 

--- a/src/dag/resolve.js
+++ b/src/dag/resolve.js
@@ -18,6 +18,7 @@ module.exports = configure(({ ky }) => {
 
     const searchParams = new URLSearchParams(options.searchParams)
     searchParams.set('arg', cidPath)
+    if (options.localResolve) searchParams.set('localResolve', options.localResolve)
 
     const res = await ky.post('dag/resolve', {
       timeout: options.timeout,


### PR DESCRIPTION
This PR supports https://github.com/ipfs/js-ipfs/pull/2689 and it enables `localResolve` option for `dag/get`.

`localResolve` will avoid resolving through different objects when set to true. 

⚠️ This is a WIP PR.